### PR TITLE
Add function to report timing and error

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,11 +24,14 @@ var (
 )
 
 type StatterConfig struct {
+	Addr                 string        // localhost:8125
+	Prefix               string        // metrics prefix
 	Agent                string        // telegraf/datadog
 	EnvName              string        // dev/test/staging/prod
 	HostName             string        // hostname
 	StuckFunctionTimeout time.Duration // stuck time
 	MockingEnabled       bool          // whether to enable mock statter, which only produce logs
+	Disabled             bool          // whether to disable metrics completely
 }
 
 func (m *StatterConfig) BaseTags() []string {
@@ -82,7 +85,16 @@ func Disable() {
 	clientMux.Unlock()
 }
 
+func InitWithConfig(cfg *StatterConfig) error {
+	return Init(cfg.Addr, cfg.Prefix, cfg)
+}
+
 func Init(addr string, prefix string, cfg *StatterConfig) error {
+	if cfg.Disabled {
+		Disable()
+		return nil
+	}
+
 	config = checkConfig(cfg)
 	if config.MockingEnabled {
 		// init a mock statter instead of real statsd client

--- a/metrics.go
+++ b/metrics.go
@@ -43,6 +43,18 @@ func ReportFuncCallAndTiming(tags ...Tags) StopTimerFunc {
 	return reportTiming(tags...)
 }
 
+func ReportFuncCallAndTimingWithErr(tags ...Tags) func(err *error) {
+	fn := CallerFuncName(1)
+	reportFunc(fn, "called", tags...)
+	stop := reportTiming(tags...)
+	return func(err *error) {
+		stop()
+		if err != nil && *err != nil {
+			ReportClosureFuncError(fn, tags...)
+		}
+	}
+}
+
 func ReportClosureFuncCall(name string, tags ...Tags) {
 	reportFunc(name, "called", tags...)
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,8 +1,11 @@
 package metrics
 
 import (
+	"errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 )
 
 func func1() string {
@@ -25,4 +28,98 @@ func TestCallerFuncName(t *testing.T) {
 func TestGetFuncName(t *testing.T) {
 	func1Name := GetFuncName(func1)
 	assert.Equal(t, func1Name, "func1")
+}
+
+func Test_ReportTimedFuncWithError(t *testing.T) {
+	var rec statterRecorder
+
+	_ = Init("", "", &StatterConfig{StuckFunctionTimeout: time.Minute, MockingEnabled: true})
+	oldClient := client
+	client = &rec
+	defer func() {
+		client = oldClient
+	}()
+
+	t.Run("can be deferred and report the error", func(t *testing.T) {
+		rec.reset()
+		exec := func() (err error) {
+			defer ReportFuncCallAndTimingWithErr(Tags{"foo": "bar"})(&err)
+
+			time.Sleep(5 * time.Millisecond)
+			return errors.New("this error should be recorder")
+		}
+
+		require.Error(t, exec())
+		require.Len(t, rec.calls, 3)
+
+		expectedTags := []string{"foo=bar", "func_name=1"}
+		assert.Equal(t, "Incr", rec.calls[0][0])
+		assert.Equal(t, "func.called", rec.calls[0][1])
+		assert.Equal(t, expectedTags, rec.calls[0][2])
+
+		assert.Equal(t, "Count", rec.calls[1][0])
+		assert.Equal(t, "func.timing", rec.calls[1][1])
+		assert.Equal(t, expectedTags, rec.calls[1][3])
+
+		assert.Equal(t, "Incr", rec.calls[2][0])
+		assert.Equal(t, "func.error", rec.calls[2][1])
+		assert.Equal(t, expectedTags, rec.calls[2][2])
+	})
+
+	t.Run("can be deferred and skip error reporting if nil", func(t *testing.T) {
+		rec.reset()
+		exec := func() {
+			var err error
+			defer ReportFuncCallAndTimingWithErr(Tags{"foo": "bar"})(&err)
+		}
+
+		exec()
+		require.Len(t, rec.calls, 2)
+
+		assert.Equal(t, "func.called", rec.calls[0][1])
+		assert.Equal(t, "func.timing", rec.calls[1][1])
+	})
+}
+
+type statterRecorder struct {
+	calls [][]interface{}
+}
+
+func (r *statterRecorder) reset() {
+	r.calls = make([][]interface{}, 0)
+}
+
+func (r *statterRecorder) Count(name string, value int64, tags []string, rate float64) error {
+	r.calls = append(r.calls, []interface{}{"Count", name, value, tags, rate})
+	return nil
+}
+
+func (r *statterRecorder) Incr(name string, tags []string, rate float64) error {
+	r.calls = append(r.calls, []interface{}{"Incr", name, tags, rate})
+	return nil
+}
+
+func (r *statterRecorder) Decr(name string, tags []string, rate float64) error {
+	r.calls = append(r.calls, []interface{}{"Count", name, tags, rate})
+	return nil
+}
+
+func (r *statterRecorder) Gauge(name string, value float64, tags []string, rate float64) error {
+	r.calls = append(r.calls, []interface{}{"Count", name, value, tags, rate})
+	return nil
+}
+
+func (r *statterRecorder) Timing(name string, value time.Duration, tags []string, rate float64) error {
+	r.calls = append(r.calls, []interface{}{"Count", name, value, tags, rate})
+	return nil
+}
+
+func (r *statterRecorder) Histogram(name string, value float64, tags []string, rate float64) error {
+	r.calls = append(r.calls, []interface{}{"Count", name, value, tags, rate})
+	return nil
+}
+
+func (r *statterRecorder) Close() error {
+	r.calls = append(r.calls, []interface{}{"Close"})
+	return nil
 }


### PR DESCRIPTION
* Adds a function to report the timing and the error, same as we have in indexer
* uses a single config file to init the system