### PR TITLE
fix: Use timing metrics to histogram in report functions

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -192,7 +192,7 @@ func reportTiming(ctx context.Context, fn string, tags ...Tags) (context.Context
 
 		clientMux.RLock()
 		defer clientMux.RUnlock()
-		client.Histogram("func.timing", float64(d.Milliseconds()), stopTagArray, 1)
+		client.Histogram("func.timing", d.Seconds()*1000, stopTagArray, 1)
 		if span != nil {
 			span.End()
 		}
@@ -233,7 +233,7 @@ func ReportClosureFuncTiming(name string, tags ...Tags) StopTimerFunc {
 
 		clientMux.RLock()
 		defer clientMux.RUnlock()
-		client.Histogram("func.timing", float64(d.Milliseconds()), stopTagArray, 1)
+		client.Histogram("func.timing", d.Seconds()*1000, stopTagArray, 1)
 	}
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -192,7 +192,7 @@ func reportTiming(ctx context.Context, fn string, tags ...Tags) (context.Context
 
 		clientMux.RLock()
 		defer clientMux.RUnlock()
-		client.Timing("func.timing", d, stopTagArray, 1)
+		client.Histogram("func.timing", float64(d.Milliseconds()), stopTagArray, 1)
 		if span != nil {
 			span.End()
 		}
@@ -233,7 +233,7 @@ func ReportClosureFuncTiming(name string, tags ...Tags) StopTimerFunc {
 
 		clientMux.RLock()
 		defer clientMux.RUnlock()
-		client.Timing("func.timing", d, stopTagArray, 1)
+		client.Histogram("func.timing", float64(d.Milliseconds()), stopTagArray, 1)
 	}
 }
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -397,7 +397,7 @@ func Test_ReportTimedFuncWithError(t *testing.T) {
 		assert.ElementsMatch(t, expectedTags, rec.calls[0][2])
 
 		expectedTags = []string{"foo=bar", "stop=error", "func_name=1"}
-		assert.Equal(t, "Timing", rec.calls[1][0])
+		assert.Equal(t, "Histogram", rec.calls[1][0])
 		assert.Equal(t, "func.timing", rec.calls[1][1])
 		assert.ElementsMatch(t, expectedTags, rec.calls[1][3])
 
@@ -438,7 +438,7 @@ func Test_ReportTimedFuncWithError(t *testing.T) {
 		assert.ElementsMatch(t, expectedTags, rec.calls[0][2])
 
 		expectedTags = []string{"foo=bar", "stop=error", "func_name=customFunc"}
-		assert.Equal(t, "Timing", rec.calls[1][0])
+		assert.Equal(t, "Histogram", rec.calls[1][0])
 		assert.Equal(t, "func.timing", rec.calls[1][1])
 		assert.ElementsMatch(t, expectedTags, rec.calls[1][3])
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified how performance timing metrics are recorded, switching from duration-based to histogram-based tracking with millisecond precision.

* **Tests**
  * Updated metric recording tests to reflect the new histogram-based timing mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->