### PR TITLE
fix: Update histogram reporting to use milliseconds for timing metrics

### DIFF
--- a/otel.go
+++ b/otel.go
@@ -169,7 +169,7 @@ func (s *otelStatter) getHistogram(name string) (otelmetric.Float64Histogram, er
 	if h, ok = s.histograms[fullName]; ok {
 		return h, nil
 	}
-	h, err := s.meter.Float64Histogram(fullName)
+	h, err := s.meter.Float64Histogram(fullName, otelmetric.WithUnit("ms"))
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +219,7 @@ func (s *otelStatter) Timing(name string, value time.Duration, tags []string, ra
 		return err
 	}
 	// OTel convention: duration histograms use seconds
-	h.Record(context.Background(), value.Seconds(), otelmetric.WithAttributes(s.tagsToAttrs(tags)...))
+	h.Record(context.Background(), value.Seconds()*1000, otelmetric.WithAttributes(s.tagsToAttrs(tags)...))
 	return nil
 }
 

--- a/otel.go
+++ b/otel.go
@@ -218,7 +218,7 @@ func (s *otelStatter) Timing(name string, value time.Duration, tags []string, ra
 	if err != nil {
 		return err
 	}
-	// OTel convention: duration histograms use seconds
+	// OTel convention: duration histograms use milliseconds
 	h.Record(context.Background(), value.Seconds()*1000, otelmetric.WithAttributes(s.tagsToAttrs(tags)...))
 	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timing metric unit from seconds to milliseconds for consistent precision in recorded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->