### PR TITLE
feat: allow otel counters

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,7 +2,9 @@ package metrics
 
 import (
 	"context"
+	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -229,6 +231,72 @@ func Init(addr string, prefix string, cfg *StatterConfig) error {
 	}
 
 	return nil
+}
+
+type ServiceConfig struct {
+	Disabled             bool
+	ServiceName          string
+	AgentID              string
+	AgentAddress         string
+	MetricsPrefix        string
+	EnvName              string
+	MockingEnabled       bool
+	MockingThreshold     time.Duration
+	MixPanelEnabled      bool
+	MixPanelProjectToken string
+	OTelInsecure         bool
+	OTelUseCounters      bool
+	TracingEnabled       bool
+	RetryInitialInterval time.Duration
+}
+
+func (c ServiceConfig) normalizePrefix() string {
+	return strings.TrimRight(c.MetricsPrefix, ".") + "."
+}
+
+func InitService(ctx context.Context, cfg ServiceConfig) (func(timeout time.Duration), error) {
+	closeFn := func(time.Duration) {}
+	if err := cfg.Validate(); err != nil {
+		return closeFn, err
+	}
+	if cfg.Disabled {
+		return closeFn, nil
+	}
+
+	if cfg.RetryInitialInterval <= 0 {
+		cfg.RetryInitialInterval = 10 * time.Second
+	}
+
+	for {
+		hostname, _ := os.Hostname()
+		err := Init(cfg.AgentAddress, cfg.normalizePrefix(), &StatterConfig{
+			Agent:                  cfg.AgentID,
+			EnvName:                cfg.EnvName,
+			HostName:               hostname,
+			MockingEnabled:         cfg.MockingEnabled,
+			MockingThreshold:       cfg.MockingThreshold,
+			MixPanelEnabled:        cfg.MixPanelEnabled,
+			MixPanelProjectToken:   cfg.MixPanelProjectToken,
+			OTELInsecure:           cfg.OTelInsecure,
+			OTELUseCounterForCount: cfg.OTelUseCounters,
+			TracingEnabled:         cfg.TracingEnabled,
+			DefaultTags:            []interface{}{"service.name", cfg.ServiceName},
+		})
+		if err != nil {
+			log.WithError(err).Warningf("metrics init failed, will retry in %s seconds", cfg.RetryInitialInterval)
+			select {
+			case <-ctx.Done():
+				return closeFn, nil
+			case <-time.After(cfg.RetryInitialInterval):
+			}
+			continue
+		}
+		log.Debugf("metrics %s client initialized at %s with prefix %s (mocking %v)",
+			cfg.AgentID, cfg.AgentAddress, cfg.normalizePrefix(), cfg.MockingEnabled)
+		break
+	}
+
+	return CloseWithTimeout, nil
 }
 
 func StartMixPanel(projectToken string) {

--- a/client.go
+++ b/client.go
@@ -38,23 +38,24 @@ var (
 )
 
 type StatterConfig struct {
-	Addr                 string            // localhost:8125
-	Prefix               string            // metrics prefix
-	Agent                string            // telegraf/datadog
-	EnvName              string            // dev/test/staging/prod
-	HostName             string            // hostname
-	Version              string            // version
-	DefaultTags          []interface{}     // default tags for all metrics
-	StuckFunctionTimeout time.Duration     // stuck time
-	MockingThreshold     time.Duration     // mocking threshold
-	MockingEnabled       bool              // whether to enable mock statter, which only produce logs
-	Disabled             bool              // whether to disable metrics completely
-	TracingEnabled       bool              // whether tracing should be enabled
-	ProfilingEnabled     bool              // whether Datadog profiling should be enabled
-	MixPanelEnabled      bool              // whether MixPanel should be enabled
-	MixPanelProjectToken string            // MixPanel project token
-	OTELInsecure         bool              // disable TLS (use for self-hosted SigNoz without TLS)
-	OTELHeaders          map[string]string // extra headers, e.g. {"signoz-access-token": "<token>"} for SigNoz Cloud
+	Addr                   string            // localhost:8125
+	Prefix                 string            // metrics prefix
+	Agent                  string            // telegraf/datadog
+	EnvName                string            // dev/test/staging/prod
+	HostName               string            // hostname
+	Version                string            // version
+	DefaultTags            []interface{}     // default tags for all metrics
+	StuckFunctionTimeout   time.Duration     // stuck time
+	MockingThreshold       time.Duration     // mocking threshold
+	MockingEnabled         bool              // whether to enable mock statter, which only produce logs
+	Disabled               bool              // whether to disable metrics completely
+	TracingEnabled         bool              // whether tracing should be enabled
+	ProfilingEnabled       bool              // whether Datadog profiling should be enabled
+	MixPanelEnabled        bool              // whether MixPanel should be enabled
+	MixPanelProjectToken   string            // MixPanel project token
+	OTELInsecure           bool              // disable TLS (use for self-hosted SigNoz without TLS)
+	OTELHeaders            map[string]string // extra headers, e.g. {"signoz-access-token": "<token>"} for SigNoz Cloud
+	OTELUseCounterForCount bool              // use monotonic OTel counters for Count/Incr instead of UpDownCounters
 }
 
 func (m *StatterConfig) BaseTags() []string {
@@ -177,6 +178,7 @@ func Init(addr string, prefix string, cfg *StatterConfig) error {
 			cfg.OTELInsecure,
 			cfg.OTELHeaders,
 			config.BaseTags(),
+			cfg.OTELUseCounterForCount,
 		)
 
 	default:

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.50.6
 	github.com/mixpanel/mixpanel-go v1.2.1
 	github.com/pkg/errors v0.9.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
@@ -120,7 +121,6 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/cobra v1.8.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect
 	github.com/tinylib/msgp v1.1.8 // indirect

--- a/otel.go
+++ b/otel.go
@@ -20,8 +20,10 @@ type otelStatter struct {
 	meter         otelmetric.Meter
 	meterProvider *sdkmetric.MeterProvider
 	prefix        string
+	useCounters   bool
 
 	mu             sync.RWMutex
+	counters       map[string]otelmetric.Int64Counter
 	updownCounters map[string]otelmetric.Int64UpDownCounter
 	gauges         map[string]otelmetric.Float64Gauge
 	histograms     map[string]otelmetric.Float64Histogram
@@ -41,7 +43,7 @@ func newOTELResource(baseTags []string) *resource.Resource {
 	return res
 }
 
-func newOTELStatter(endpoint, prefix string, insecure bool, headers map[string]string, baseTags []string) (Statter, error) {
+func newOTELStatter(endpoint, prefix string, insecure bool, headers map[string]string, baseTags []string, useCounters bool) (Statter, error) {
 	ctx := context.Background()
 
 	metricOpts := []otlpmetricgrpc.Option{
@@ -70,6 +72,8 @@ func newOTELStatter(endpoint, prefix string, insecure bool, headers map[string]s
 		meter:          mp.Meter(prefix),
 		meterProvider:  mp,
 		prefix:         prefix,
+		useCounters:    useCounters,
+		counters:       make(map[string]otelmetric.Int64Counter),
 		updownCounters: make(map[string]otelmetric.Int64UpDownCounter),
 		gauges:         make(map[string]otelmetric.Float64Gauge),
 		histograms:     make(map[string]otelmetric.Float64Histogram),
@@ -112,6 +116,27 @@ func (s *otelStatter) tagsToAttrs(tags []string) []attribute.KeyValue {
 		attrs = append(attrs, attribute.String(tag[:idx], tag[idx+1:]))
 	}
 	return attrs
+}
+
+func (s *otelStatter) getCounter(name string) (otelmetric.Int64Counter, error) {
+	fullName := s.prefix + name
+	s.mu.RLock()
+	c, ok := s.counters[fullName]
+	s.mu.RUnlock()
+	if ok {
+		return c, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if c, ok = s.counters[fullName]; ok {
+		return c, nil
+	}
+	c, err := s.meter.Int64Counter(fullName)
+	if err != nil {
+		return nil, err
+	}
+	s.counters[fullName] = c
+	return c, nil
 }
 
 func (s *otelStatter) getUpDownCounter(name string) (otelmetric.Int64UpDownCounter, error) {
@@ -178,6 +203,14 @@ func (s *otelStatter) getHistogram(name string) (otelmetric.Float64Histogram, er
 }
 
 func (s *otelStatter) Count(name string, value int64, tags []string, rate float64) error {
+	if s.useCounters {
+		c, err := s.getCounter(name)
+		if err != nil {
+			return err
+		}
+		c.Add(context.Background(), value, otelmetric.WithAttributes(s.tagsToAttrs(tags)...))
+		return nil
+	}
 	c, err := s.getUpDownCounter(name)
 	if err != nil {
 		return err
@@ -187,6 +220,14 @@ func (s *otelStatter) Count(name string, value int64, tags []string, rate float6
 }
 
 func (s *otelStatter) Incr(name string, tags []string, rate float64) error {
+	if s.useCounters {
+		c, err := s.getCounter(name)
+		if err != nil {
+			return err
+		}
+		c.Add(context.Background(), 1, otelmetric.WithAttributes(s.tagsToAttrs(tags)...))
+		return nil
+	}
 	c, err := s.getUpDownCounter(name)
 	if err != nil {
 		return err

--- a/otel.go
+++ b/otel.go
@@ -284,3 +284,39 @@ func (s *otelStatter) Close() error {
 func (s *otelStatter) CloseCtx(ctx context.Context) error {
 	return s.meterProvider.Shutdown(ctx)
 }
+
+func OTelSetupHistogram(name string, opts ...otelmetric.Float64HistogramOption) error {
+	clientMux.RLock()
+	c := client
+	clientMux.RUnlock()
+
+	if c == nil {
+		return nil
+	}
+
+	s, ok := c.(*otelStatter)
+	if !ok {
+		return nil
+	}
+
+	fullName := s.prefix + name
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.histograms[fullName]; exists {
+		return fmt.Errorf("histogram %s already initialized", fullName)
+	}
+
+	finalOpts := append([]otelmetric.Float64HistogramOption{
+		otelmetric.WithUnit("ms"),
+	}, opts...)
+
+	h, err := s.meter.Float64Histogram(fullName, finalOpts...)
+	if err != nil {
+		return err
+	}
+
+	s.histograms[fullName] = h
+	return nil
+}

--- a/otel.go
+++ b/otel.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -204,6 +205,9 @@ func (s *otelStatter) getHistogram(name string) (otelmetric.Float64Histogram, er
 
 func (s *otelStatter) Count(name string, value int64, tags []string, rate float64) error {
 	if s.useCounters {
+		if value < 0 {
+			return fmt.Errorf("counter value must be non-negative")
+		}
 		c, err := s.getCounter(name)
 		if err != nil {
 			return err

--- a/otel_test.go
+++ b/otel_test.go
@@ -76,6 +76,17 @@ func TestOTELCountCanUseCounter(t *testing.T) {
 	require.EqualValues(t, 6, sum.DataPoints[0].Value)
 }
 
+func TestOTELCountRejectsNegativeValueWithCounterOption(t *testing.T) {
+	statter, _ := newTestOTELStatter(true)
+	t.Cleanup(func() {
+		require.NoError(t, statter.Close())
+	})
+
+	err := statter.Count("events.total", -1, []string{"status=ok"}, 1)
+	require.EqualError(t, err, "counter value must be non-negative")
+	require.Empty(t, statter.counters)
+}
+
 func TestOTELDecrUsesUpDownCounterWithCounterOption(t *testing.T) {
 	statter, reader := newTestOTELStatter(true)
 	t.Cleanup(func() {

--- a/otel_test.go
+++ b/otel_test.go
@@ -1,0 +1,91 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func newTestOTELStatter(useCounters bool) (*otelStatter, *sdkmetric.ManualReader) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	return &otelStatter{
+		meter:          mp.Meter("test"),
+		meterProvider:  mp,
+		useCounters:    useCounters,
+		counters:       make(map[string]otelmetric.Int64Counter),
+		updownCounters: make(map[string]otelmetric.Int64UpDownCounter),
+		gauges:         make(map[string]otelmetric.Float64Gauge),
+		histograms:     make(map[string]otelmetric.Float64Histogram),
+	}, reader
+}
+
+func collectOTELMetric(t *testing.T, reader *sdkmetric.ManualReader, name string) metricdata.Metrics {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m
+			}
+		}
+	}
+	require.Failf(t, "metric not found", "metric %q not found", name)
+	return metricdata.Metrics{}
+}
+
+func requireOTELInt64Sum(t *testing.T, m metricdata.Metrics) metricdata.Sum[int64] {
+	t.Helper()
+
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.Truef(t, ok, "expected int64 sum, got %T", m.Data)
+	return sum
+}
+
+func TestOTELCountDefaultsToUpDownCounter(t *testing.T) {
+	statter, reader := newTestOTELStatter(false)
+	t.Cleanup(func() {
+		require.NoError(t, statter.Close())
+	})
+
+	require.NoError(t, statter.Count("events.total", 5, []string{"status=ok"}, 1))
+
+	sum := requireOTELInt64Sum(t, collectOTELMetric(t, reader, "events.total"))
+	require.False(t, sum.IsMonotonic)
+	require.Len(t, sum.DataPoints, 1)
+	require.EqualValues(t, 5, sum.DataPoints[0].Value)
+}
+
+func TestOTELCountCanUseCounter(t *testing.T) {
+	statter, reader := newTestOTELStatter(true)
+	t.Cleanup(func() {
+		require.NoError(t, statter.Close())
+	})
+
+	require.NoError(t, statter.Count("events.total", 5, []string{"status=ok"}, 1))
+	require.NoError(t, statter.Incr("events.total", []string{"status=ok"}, 1))
+
+	sum := requireOTELInt64Sum(t, collectOTELMetric(t, reader, "events.total"))
+	require.True(t, sum.IsMonotonic)
+	require.Len(t, sum.DataPoints, 1)
+	require.EqualValues(t, 6, sum.DataPoints[0].Value)
+}
+
+func TestOTELDecrUsesUpDownCounterWithCounterOption(t *testing.T) {
+	statter, reader := newTestOTELStatter(true)
+	t.Cleanup(func() {
+		require.NoError(t, statter.Close())
+	})
+
+	require.NoError(t, statter.Decr("active.requests", []string{"status=ok"}, 1))
+
+	sum := requireOTELInt64Sum(t, collectOTELMetric(t, reader, "active.requests"))
+	require.False(t, sum.IsMonotonic)
+	require.Len(t, sum.DataPoints, 1)
+	require.EqualValues(t, -1, sum.DataPoints[0].Value)
+}

--- a/pflag/service_config.go
+++ b/pflag/service_config.go
@@ -1,0 +1,133 @@
+package pflag
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/InjectiveLabs/metrics"
+	spf13pflag "github.com/spf13/pflag"
+)
+
+const (
+	serviceConfigDisabledFlag             = "metrics-disabled"
+	serviceConfigAgentIDFlag              = "metrics-agent-id"
+	serviceConfigAgentAddressFlag         = "metrics-agent-address"
+	serviceConfigPrefixFlag               = "metrics-prefix"
+	serviceConfigEnvNameFlag              = "metrics-env-name"
+	serviceConfigMockingEnabledFlag       = "metrics-mocking-enabled"
+	serviceConfigMockingThresholdFlag     = "metrics-mocking-threshold"
+	serviceConfigMixPanelEnabledFlag      = "metrics-mixpanel-enabled"
+	serviceConfigMixPanelProjectTokenFlag = "metrics-mixpanel-project-token"
+	serviceConfigOTELInsecureFlag         = "metrics-otel-insecure"
+	serviceConfigTracingEnabledFlag       = "metrics-tracing-enabled"
+)
+
+func RegisterServiceConfigFlags(flags *spf13pflag.FlagSet) {
+	if flags == nil {
+		return
+	}
+
+	flags.Bool(serviceConfigDisabledFlag, true, "disable metrics collection")
+	flags.String(serviceConfigAgentIDFlag, "", "metrics agent identifier")
+	flags.String(serviceConfigAgentAddressFlag, "", "metrics agent address")
+	flags.String(serviceConfigPrefixFlag, "", "metrics name prefix")
+	flags.String(serviceConfigEnvNameFlag, "", "metrics environment name")
+	flags.Bool(serviceConfigMockingEnabledFlag, false, "enable metrics mocking")
+	flags.Duration(serviceConfigMockingThresholdFlag, 0, "metrics mocking threshold")
+	flags.Bool(serviceConfigMixPanelEnabledFlag, false, "enable Mixpanel metrics")
+	flags.String(serviceConfigMixPanelProjectTokenFlag, "", "Mixpanel project token")
+	flags.Bool(serviceConfigOTELInsecureFlag, false, "use insecure OpenTelemetry transport")
+	flags.Bool(serviceConfigTracingEnabledFlag, false, "enable metrics tracing")
+}
+
+func ConfigureServiceConfig(serviceName, envPrefix string, flags *spf13pflag.FlagSet) (metrics.ServiceConfig, error) {
+	cfg := metrics.ServiceConfig{
+		ServiceName: serviceName,
+	}
+	if err := cfg.ConfigureFromEnv(envPrefix); err != nil {
+		return cfg, fmt.Errorf("configure service config from env: %w", err)
+	}
+	if err := ConfigureServiceConfigFromFlagSet(&cfg, flags); err != nil {
+		return cfg, fmt.Errorf("configure service config from flags: %w", err)
+	}
+
+	return cfg, nil
+}
+
+func InitService(ctx context.Context, serviceName, envPrefix string, flags *spf13pflag.FlagSet) (func(timeout time.Duration), error) {
+	closeFn := func(time.Duration) {}
+
+	cfg, err := ConfigureServiceConfig(serviceName, envPrefix, flags)
+	if err != nil {
+		return closeFn, err
+	}
+
+	return metrics.InitService(ctx, cfg)
+}
+
+// ConfigureServiceConfigFromFlagSet overlays ServiceConfig fields from explicitly changed flags.
+func ConfigureServiceConfigFromFlagSet(cfg *metrics.ServiceConfig, flags *spf13pflag.FlagSet) error {
+	if cfg == nil {
+		return nil
+	}
+
+	for _, opt := range []struct {
+		name  string
+		apply func(*spf13pflag.FlagSet, string) error
+	}{
+		{serviceConfigDisabledFlag, getBoolFlag(&cfg.Disabled)},
+		{serviceConfigAgentIDFlag, getStringFlag(&cfg.AgentID)},
+		{serviceConfigAgentAddressFlag, getStringFlag(&cfg.AgentAddress)},
+		{serviceConfigPrefixFlag, getStringFlag(&cfg.MetricsPrefix)},
+		{serviceConfigEnvNameFlag, getStringFlag(&cfg.EnvName)},
+		{serviceConfigMockingEnabledFlag, getBoolFlag(&cfg.MockingEnabled)},
+		{serviceConfigMockingThresholdFlag, getDurationFlag(&cfg.MockingThreshold)},
+		{serviceConfigMixPanelEnabledFlag, getBoolFlag(&cfg.MixPanelEnabled)},
+		{serviceConfigMixPanelProjectTokenFlag, getStringFlag(&cfg.MixPanelProjectToken)},
+		{serviceConfigOTELInsecureFlag, getBoolFlag(&cfg.OTelInsecure)},
+		{serviceConfigTracingEnabledFlag, getBoolFlag(&cfg.TracingEnabled)},
+	} {
+		if flags == nil || !flags.Changed(opt.name) {
+			continue
+		}
+		if err := opt.apply(flags, opt.name); err != nil {
+			return fmt.Errorf("parse flag %s: %w", opt.name, err)
+		}
+	}
+
+	return nil
+}
+
+func getStringFlag(dst *string) func(*spf13pflag.FlagSet, string) error {
+	return func(flags *spf13pflag.FlagSet, name string) error {
+		parsed, err := flags.GetString(name)
+		if err != nil {
+			return err
+		}
+		*dst = parsed
+		return nil
+	}
+}
+
+func getBoolFlag(dst *bool) func(*spf13pflag.FlagSet, string) error {
+	return func(flags *spf13pflag.FlagSet, name string) error {
+		parsed, err := flags.GetBool(name)
+		if err != nil {
+			return err
+		}
+		*dst = parsed
+		return nil
+	}
+}
+
+func getDurationFlag(dst *time.Duration) func(*spf13pflag.FlagSet, string) error {
+	return func(flags *spf13pflag.FlagSet, name string) error {
+		parsed, err := flags.GetDuration(name)
+		if err != nil {
+			return err
+		}
+		*dst = parsed
+		return nil
+	}
+}

--- a/pflag/service_config_test.go
+++ b/pflag/service_config_test.go
@@ -1,0 +1,131 @@
+package pflag
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/InjectiveLabs/metrics"
+	spf13pflag "github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureServiceConfigFromFlagSetWithChangedFlags(t *testing.T) {
+	flags := spf13pflag.NewFlagSet("test", spf13pflag.ContinueOnError)
+	RegisterServiceConfigFlags(flags)
+	require.NoError(t, flags.Set(serviceConfigDisabledFlag, "false"))
+	require.NoError(t, flags.Set(serviceConfigAgentIDFlag, "app-local"))
+	require.NoError(t, flags.Set(serviceConfigAgentAddressFlag, "localhost:8125"))
+	require.NoError(t, flags.Set(serviceConfigPrefixFlag, "app.local"))
+	require.NoError(t, flags.Set(serviceConfigEnvNameFlag, "local"))
+	require.NoError(t, flags.Set(serviceConfigMockingEnabledFlag, "true"))
+	require.NoError(t, flags.Set(serviceConfigMockingThresholdFlag, "50ms"))
+	require.NoError(t, flags.Set(serviceConfigMixPanelEnabledFlag, "true"))
+	require.NoError(t, flags.Set(serviceConfigMixPanelProjectTokenFlag, "project-token"))
+	require.NoError(t, flags.Set(serviceConfigOTELInsecureFlag, "true"))
+	require.NoError(t, flags.Set(serviceConfigTracingEnabledFlag, "true"))
+
+	cfg := metrics.ServiceConfig{
+		ServiceName:     "app",
+		OTelUseCounters: true,
+	}
+
+	require.NoError(t, ConfigureServiceConfigFromFlagSet(&cfg, flags))
+	require.Equal(t, metrics.ServiceConfig{
+		Disabled:             false,
+		ServiceName:          "app",
+		AgentID:              "app-local",
+		AgentAddress:         "localhost:8125",
+		MetricsPrefix:        "app.local",
+		EnvName:              "local",
+		MockingEnabled:       true,
+		MockingThreshold:     50 * time.Millisecond,
+		MixPanelEnabled:      true,
+		MixPanelProjectToken: "project-token",
+		OTelInsecure:         true,
+		OTelUseCounters:      true,
+		TracingEnabled:       true,
+	}, cfg)
+}
+
+func TestConfigureServiceConfigFromFlagSetKeepsExistingValuesWhenUnchanged(t *testing.T) {
+	flags := spf13pflag.NewFlagSet("test", spf13pflag.ContinueOnError)
+	RegisterServiceConfigFlags(flags)
+
+	cfg := metrics.ServiceConfig{
+		AgentID:          metrics.TelegrafAgent,
+		AgentAddress:     "localhost:8125",
+		MetricsPrefix:    "default",
+		EnvName:          "local",
+		MockingThreshold: time.Second,
+	}
+
+	require.NoError(t, ConfigureServiceConfigFromFlagSet(&cfg, flags))
+	require.False(t, cfg.Disabled)
+	require.Equal(t, metrics.TelegrafAgent, cfg.AgentID)
+	require.Equal(t, "localhost:8125", cfg.AgentAddress)
+	require.Equal(t, "default", cfg.MetricsPrefix)
+	require.Equal(t, "local", cfg.EnvName)
+	require.Equal(t, time.Second, cfg.MockingThreshold)
+}
+
+func TestConfigureServiceConfigFromFlagSetAllowsExplicitDefaultValue(t *testing.T) {
+	flags := spf13pflag.NewFlagSet("test", spf13pflag.ContinueOnError)
+	RegisterServiceConfigFlags(flags)
+	require.NoError(t, flags.Set(serviceConfigDisabledFlag, "true"))
+
+	cfg := metrics.ServiceConfig{Disabled: false}
+	require.NoError(t, ConfigureServiceConfigFromFlagSet(&cfg, flags))
+	require.True(t, cfg.Disabled)
+}
+
+func TestConfigureServiceConfigFromFlagSetSkipsNilFlagSet(t *testing.T) {
+	cfg := metrics.ServiceConfig{AgentID: metrics.TelegrafAgent}
+	require.NoError(t, ConfigureServiceConfigFromFlagSet(&cfg, nil))
+	require.Equal(t, metrics.TelegrafAgent, cfg.AgentID)
+}
+
+func TestConfigureServiceConfigFromFlagSetSkipsNilConfig(t *testing.T) {
+	flags := spf13pflag.NewFlagSet("test", spf13pflag.ContinueOnError)
+	RegisterServiceConfigFlags(flags)
+	require.NoError(t, ConfigureServiceConfigFromFlagSet(nil, flags))
+}
+
+func TestConfigureServiceConfigLoadsEnvAndFlagOverrides(t *testing.T) {
+	t.Setenv("APPNAME_METRICS_DISABLED", "false")
+	t.Setenv("APPNAME_METRICS_AGENT_ID", "env-agent")
+	t.Setenv("APPNAME_METRICS_AGENT_ADDRESS", "env-host:8125")
+	t.Setenv("APPNAME_METRICS_PREFIX", "env.prefix")
+	t.Setenv("APPNAME_METRICS_ENV_NAME", "local")
+
+	flags := spf13pflag.NewFlagSet("test", spf13pflag.ContinueOnError)
+	RegisterServiceConfigFlags(flags)
+	require.NoError(t, flags.Set(serviceConfigAgentIDFlag, "flag-agent"))
+
+	cfg, err := ConfigureServiceConfig("app", "APPNAME", flags)
+	require.NoError(t, err)
+	require.Equal(t, "app", cfg.ServiceName)
+	require.False(t, cfg.Disabled)
+	require.Equal(t, "flag-agent", cfg.AgentID)
+	require.Equal(t, "env-host:8125", cfg.AgentAddress)
+	require.Equal(t, "env.prefix", cfg.MetricsPrefix)
+	require.Equal(t, "local", cfg.EnvName)
+}
+
+func TestConfigureServiceConfigWrapsEnvErrors(t *testing.T) {
+	t.Setenv("APPNAME_METRICS_MOCKING_THRESHOLD", "eventually")
+
+	_, err := ConfigureServiceConfig("app", "APPNAME", nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "configure service config from env")
+	require.ErrorContains(t, err, "APPNAME_METRICS_MOCKING_THRESHOLD")
+}
+
+func TestInitServiceWithDisabledConfig(t *testing.T) {
+	t.Setenv("APPNAME_METRICS_DISABLED", "true")
+
+	closeFn, err := InitService(context.Background(), "app", "APPNAME", nil)
+	require.NoError(t, err)
+	require.NotNil(t, closeFn)
+	closeFn(time.Second)
+}

--- a/service_config.go
+++ b/service_config.go
@@ -1,0 +1,110 @@
+package metrics
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ConfigureFromEnv overlays ServiceConfig fields from the default metrics env vars.
+// Prefixes "APPNAME" and "APPNAME_METRICS" both map to APPNAME_METRICS_DISABLED.
+func (c *ServiceConfig) ConfigureFromEnv(prefix string) error {
+	for _, opt := range []struct {
+		name  string
+		apply func(string) error
+	}{
+		{"METRICS_DISABLED", setBool(&c.Disabled)},
+		{"METRICS_AGENT_ID", setString(&c.AgentID)},
+		{"METRICS_AGENT_ADDRESS", setString(&c.AgentAddress)},
+		{"METRICS_PREFIX", setString(&c.MetricsPrefix)},
+		{"METRICS_ENV_NAME", setString(&c.EnvName)},
+		{"METRICS_MOCKING_ENABLED", setBool(&c.MockingEnabled)},
+		{"METRICS_MOCKING_THRESHOLD", setDuration(&c.MockingThreshold)},
+		{"METRICS_MIXPANEL_ENABLED", setBool(&c.MixPanelEnabled)},
+		{"METRICS_MIXPANEL_PROJECT_TOKEN", setString(&c.MixPanelProjectToken)},
+		{"METRICS_OTEL_INSECURE", setBool(&c.OTelInsecure)},
+		{"METRICS_TRACING_ENABLED", setBool(&c.TracingEnabled)},
+	} {
+		envName := prefixedEnvName(prefix, opt.name)
+		value, ok := os.LookupEnv(envName)
+		if !ok {
+			continue
+		}
+		if err := opt.apply(value); err != nil {
+			return fmt.Errorf("parse %s: %w", envName, err)
+		}
+	}
+
+	return nil
+}
+
+func (c ServiceConfig) Validate() error {
+	if c.Disabled {
+		return nil
+	}
+
+	var missing []string
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"ServiceName", c.ServiceName},
+		{"AgentID", c.AgentID},
+		{"AgentAddress", c.AgentAddress},
+		{"EnvName", c.EnvName},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			missing = append(missing, field.name)
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required ServiceConfig fields: %s", strings.Join(missing, ", "))
+	}
+
+	return nil
+}
+
+func prefixedEnvName(prefix, name string) string {
+	prefix = strings.Trim(prefix, "_")
+	if prefix == "" {
+		return name
+	}
+	if strings.HasSuffix(prefix, "_METRICS") {
+		if suffix, ok := strings.CutPrefix(name, "METRICS_"); ok {
+			return prefix + "_" + suffix
+		}
+	}
+	return prefix + "_" + name
+}
+
+func setString(dst *string) func(string) error {
+	return func(value string) error {
+		*dst = value
+		return nil
+	}
+}
+
+func setBool(dst *bool) func(string) error {
+	return func(value string) error {
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+		*dst = parsed
+		return nil
+	}
+}
+
+func setDuration(dst *time.Duration) func(string) error {
+	return func(value string) error {
+		parsed, err := time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+		*dst = parsed
+		return nil
+	}
+}

--- a/service_config_test.go
+++ b/service_config_test.go
@@ -1,0 +1,121 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceConfigConfigureFromEnvWithPrefix(t *testing.T) {
+	t.Setenv("APPNAME_METRICS_DISABLED", "false")
+	t.Setenv("APPNAME_METRICS_AGENT_ID", "app-local")
+	t.Setenv("APPNAME_METRICS_AGENT_ADDRESS", "localhost:8125")
+	t.Setenv("APPNAME_METRICS_PREFIX", "app.local")
+	t.Setenv("APPNAME_METRICS_ENV_NAME", "local")
+	t.Setenv("APPNAME_METRICS_MOCKING_ENABLED", "true")
+	t.Setenv("APPNAME_METRICS_MOCKING_THRESHOLD", "50ms")
+	t.Setenv("APPNAME_METRICS_MIXPANEL_ENABLED", "true")
+	t.Setenv("APPNAME_METRICS_MIXPANEL_PROJECT_TOKEN", "project-token")
+	t.Setenv("APPNAME_METRICS_OTEL_INSECURE", "true")
+	t.Setenv("APPNAME_METRICS_TRACING_ENABLED", "true")
+
+	cfg := ServiceConfig{
+		ServiceName:     "app",
+		OTelUseCounters: true,
+	}
+
+	require.NoError(t, cfg.ConfigureFromEnv("APPNAME"))
+	require.Equal(t, ServiceConfig{
+		Disabled:             false,
+		ServiceName:          "app",
+		AgentID:              "app-local",
+		AgentAddress:         "localhost:8125",
+		MetricsPrefix:        "app.local",
+		EnvName:              "local",
+		MockingEnabled:       true,
+		MockingThreshold:     50 * time.Millisecond,
+		MixPanelEnabled:      true,
+		MixPanelProjectToken: "project-token",
+		OTelInsecure:         true,
+		OTelUseCounters:      true,
+		TracingEnabled:       true,
+	}, cfg)
+}
+
+func TestServiceConfigConfigureFromEnvKeepsExistingValuesWhenUnset(t *testing.T) {
+	cfg := ServiceConfig{
+		AgentID:          TelegrafAgent,
+		AgentAddress:     "localhost:8125",
+		MetricsPrefix:    "default",
+		MockingThreshold: time.Second,
+	}
+
+	require.NoError(t, cfg.ConfigureFromEnv("MISSING"))
+	require.Equal(t, TelegrafAgent, cfg.AgentID)
+	require.Equal(t, "localhost:8125", cfg.AgentAddress)
+	require.Equal(t, "default", cfg.MetricsPrefix)
+	require.Equal(t, time.Second, cfg.MockingThreshold)
+}
+
+func TestServiceConfigConfigureFromEnvReportsInvalidValues(t *testing.T) {
+	t.Setenv("APPNAME_METRICS_MOCKING_THRESHOLD", "eventually")
+
+	var cfg ServiceConfig
+	err := cfg.ConfigureFromEnv("APPNAME")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "APPNAME_METRICS_MOCKING_THRESHOLD")
+}
+
+func TestServiceConfigConfigureFromEnvWithoutPrefix(t *testing.T) {
+	t.Setenv("METRICS_AGENT_ID", OTELAgent)
+
+	var cfg ServiceConfig
+	require.NoError(t, cfg.ConfigureFromEnv(""))
+	require.Equal(t, OTELAgent, cfg.AgentID)
+}
+
+func TestServiceConfigConfigureFromEnvWithFullMetricsPrefix(t *testing.T) {
+	t.Setenv("APPNAME_METRICS_DISABLED", "true")
+
+	var cfg ServiceConfig
+	require.NoError(t, cfg.ConfigureFromEnv("APPNAME_METRICS"))
+	require.True(t, cfg.Disabled)
+}
+
+func TestServiceConfigValidateRequiresFields(t *testing.T) {
+	err := ServiceConfig{}.Validate()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ServiceName")
+	require.ErrorContains(t, err, "AgentID")
+	require.ErrorContains(t, err, "AgentAddress")
+	require.ErrorContains(t, err, "EnvName")
+}
+
+func TestServiceConfigValidateSkipsRequiredFieldsWhenDisabled(t *testing.T) {
+	require.NoError(t, ServiceConfig{Disabled: true}.Validate())
+}
+
+func TestServiceConfigValidateAcceptsRequiredFields(t *testing.T) {
+	cfg := ServiceConfig{
+		ServiceName:  "app",
+		AgentID:      TelegrafAgent,
+		AgentAddress: "localhost:8125",
+		EnvName:      "local",
+	}
+
+	require.NoError(t, cfg.Validate())
+}
+
+func TestServiceConfigValidateTrimsRequiredFields(t *testing.T) {
+	cfg := ServiceConfig{
+		ServiceName:  " ",
+		AgentID:      TelegrafAgent,
+		AgentAddress: "localhost:8125",
+		EnvName:      "local",
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ServiceName")
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Option to emit Count/Incr as monotonic OpenTelemetry counters; Count rejects negative values when enabled.
  - Public helper to initialize OTEL histograms (milliseconds unit).
  - Service init helper that normalizes metrics prefix, captures hostname, retries initialization, and returns a closable shutdown function.
  - Service-level configuration can be populated from environment variables and validated.

* **Tests**
  - Tests validating counter-only rejection of negative Count and comprehensive ServiceConfig env/validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->