### PR TITLE
fix: rebuild the UDP statsd client so it cannot report into a dead socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,26 @@
 
 - OpenTelemetry (OTEL)
 
+### Statsd client refresh
+
+The Telegraf and DataDog statters send over UDP. They resolve their address and dial
+once, at construction, and then hold that socket for the life of the process — and
+nothing in the write path can tell that the socket has stopped being delivered,
+because a connectionless send to a dead peer still succeeds locally. A process that
+outlives the agent it was pointed at therefore keeps "reporting" into a hole,
+silently, with no errors and a healthy-looking service.
+
+To prevent that, the UDP client is rebuilt every `DefaultRefreshInterval`
+(5 minutes). A rebuild is a UDP dial with no handshake, and the client it replaces is
+closed, which flushes whatever it had buffered.
+
+- `InitService` starts the refresh automatically. Tune it with
+  `ServiceConfig.RefreshInterval`, or set that to a negative value to switch it off.
+- Callers that use `Init` directly should call `StartRefresh(ctx, addr, prefix, 0)`
+  once afterwards.
+
+OTEL is deliberately left alone: it exports over gRPC/HTTP, which redials on its own.
+
 ### Acknowledgement
 
 - Special thanks maintainers of injective-exchange/metrics, this package derives from this PR: https://github.com/InjectiveLabs/injective-exchange/pull/451

--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ closed, which flushes whatever it had buffered.
   `ServiceConfig.RefreshInterval`, or set that to a negative value to switch it off.
 - Callers that use `Init` directly should call `StartRefresh(ctx, addr, prefix, 0)`
   once afterwards.
-- A later `Init` retires the loop the previous one started, so a re-init cannot leave
-  a refresh rebuilding for the address and tag format of the config it replaced.
+- A later `Init` retires the loop the previous one started, immediately rather than
+  at that loop's next tick, so a re-init cannot leave a refresh rebuilding for the
+  address and tag format of the config it replaced.
+- An `Init` that fails leaves the previous client and config in place; nothing is
+  published until every step that can fail has succeeded.
 
 OTEL is deliberately left alone: it exports over gRPC/HTTP, which redials on its own.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ closed, which flushes whatever it had buffered.
   `ServiceConfig.RefreshInterval`, or set that to a negative value to switch it off.
 - Callers that use `Init` directly should call `StartRefresh(ctx, addr, prefix, 0)`
   once afterwards.
+- A later `Init` retires the loop the previous one started, so a re-init cannot leave
+  a refresh rebuilding for the address and tag format of the config it replaced.
 
 OTEL is deliberately left alone: it exports over gRPC/HTTP, which redials on its own.
 

--- a/client.go
+++ b/client.go
@@ -150,50 +150,12 @@ func Init(addr string, prefix string, cfg *StatterConfig) error {
 		return nil
 	}
 
-	var (
-		statter Statter
-		err     error
-	)
-
-	switch cfg.Agent {
-	case DatadogAgent:
-		statter, err = dogstatsd.New(
-			addr,
-			dogstatsd.WithNamespace(prefix),
-			dogstatsd.WithWriteTimeout(time.Duration(10)*time.Second),
-			dogstatsd.WithTags(config.BaseTags()),
-		)
-
-	case TelegrafAgent:
-		statter, err = newTelegrafStatter(
-			statsd.Address(addr),
-			statsd.Prefix(prefix),
-			statsd.ErrorHandler(errHandler),
-			statsd.TagsFormat(statsd.InfluxDB),
-			statsd.Tags(config.BaseTags()...),
-		)
-
-	case OTELAgent:
-		statter, err = newOTELStatter(
-			addr,
-			prefix,
-			cfg.OTELInsecure,
-			cfg.OTELHeaders,
-			config.BaseTags(),
-			cfg.OTELUseCounterForCount,
-		)
-
-	default:
-		return ErrUnsupportedAgent
-	}
-
+	statter, err := newStatter(addr, prefix, cfg)
 	if err != nil {
-		err = errors.Wrap(err, "statsd init failed")
 		return err
 	}
-	clientMux.Lock()
-	client = statter
-	clientMux.Unlock()
+
+	swapStatter(statter)
 
 	// OpenTelemetry tracing via DataDog provider
 	if cfg.Agent == DatadogAgent && cfg.TracingEnabled {
@@ -233,6 +195,150 @@ func Init(addr string, prefix string, cfg *StatterConfig) error {
 	return nil
 }
 
+// newStatter builds a statter for the configured agent. Split out of Init so the
+// refresh loop can rebuild ONLY the statter: Init also wires up tracing, profiling
+// and MixPanel, and those are process-global, one-shot setups that must not be
+// repeated.
+func newStatter(addr, prefix string, cfg *StatterConfig) (Statter, error) {
+	var (
+		statter Statter
+		err     error
+	)
+
+	switch cfg.Agent {
+	case DatadogAgent:
+		statter, err = dogstatsd.New(
+			addr,
+			dogstatsd.WithNamespace(prefix),
+			dogstatsd.WithWriteTimeout(time.Duration(10)*time.Second),
+			dogstatsd.WithTags(config.BaseTags()),
+		)
+
+	case TelegrafAgent:
+		statter, err = newTelegrafStatter(
+			statsd.Address(addr),
+			statsd.Prefix(prefix),
+			statsd.ErrorHandler(errHandler),
+			statsd.TagsFormat(statsd.InfluxDB),
+			statsd.Tags(config.BaseTags()...),
+		)
+
+	case OTELAgent:
+		statter, err = newOTELStatter(
+			addr,
+			prefix,
+			cfg.OTELInsecure,
+			cfg.OTELHeaders,
+			config.BaseTags(),
+			cfg.OTELUseCounterForCount,
+		)
+
+	default:
+		return nil, ErrUnsupportedAgent
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "statsd init failed")
+	}
+
+	return statter, nil
+}
+
+// swapStatter installs a new statter and closes the one it replaces. Init used to
+// overwrite the package-level client without closing it, which leaked the old
+// client's socket and flush goroutine on every re-init - harmless when Init ran
+// once per process, a slow leak now that the refresh loop calls it repeatedly.
+func swapStatter(statter Statter) {
+	clientMux.Lock()
+	previous := client
+	client = statter
+	clientMux.Unlock()
+
+	if previous != nil {
+		_ = previous.Close()
+	}
+}
+
+// statterNeedsRefresh reports whether this agent talks over a connectionless
+// socket that can silently stop being delivered. See startStatterRefresh.
+//
+// OTEL is excluded on purpose: it exports over gRPC/HTTP, which detects a broken
+// connection and redials on its own, and rebuilding its exporter on a timer would
+// throw away batched points for no benefit.
+func statterNeedsRefresh(agent string) bool {
+	return agent == DatadogAgent || agent == TelegrafAgent
+}
+
+// startStatterRefresh periodically rebuilds the statsd client.
+//
+// The UDP statters resolve their address and dial ONCE, at construction, and then
+// hold that socket for the lifetime of the process. Nothing in the write path can
+// notice that the socket has stopped being delivered, because there is nothing to
+// notice: sends to a dead peer succeed locally, and a connectionless socket gets
+// no signal back. So a process that outlives the agent it was pointed at goes on
+// "reporting" into a hole, silently, forever.
+//
+// That is not hypothetical. On 2026-09-02 every one of the 46 statsd-emitting pods
+// on ovh-prod-mainnet-eu that had started before its node's otel-agent was replaced
+// was found to be reporting nothing - the agents' statsd receivers had accepted zero
+// points in 18h, while the pods logged no errors and stayed healthy. The metrics only
+// came back when the pods were restarted, by hand, one deployment at a time.
+//
+// Re-resolving DNS would not have caught it: the Service ClusterIP never changed,
+// only the pod behind it. Rebuilding the socket is what recovers, so that is what
+// this does. It is cheap - a UDP dial, no handshake - and the old client is closed,
+// which flushes whatever it had buffered.
+func startStatterRefresh(ctx context.Context, addr, prefix string, cfg *StatterConfig, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			statter, err := newStatter(addr, prefix, cfg)
+			if err != nil {
+				// Keep serving with the existing client. A refresh that cannot build a
+				// replacement is strictly better off leaving the old one in place: it
+				// might still work, and a nil client silently drops every metric.
+				log.WithError(err).Warningln("metrics client refresh failed, keeping the current one")
+				continue
+			}
+
+			swapStatter(statter)
+		}
+	}
+}
+
+// StartRefresh starts the periodic statsd client rebuild for callers that use Init
+// directly instead of InitService, which starts it for them. Call it once, after a
+// successful Init, with the same addr and prefix; it returns immediately and the
+// loop stops when ctx is done.
+//
+// This exists because most services still on the plain Init path predate
+// InitService, and they are exactly the ones that were found reporting into dead
+// sockets. Passing interval <= 0 uses DefaultRefreshInterval.
+//
+// It is a no-op when Init has not run, when metrics are mocked, and for agents that
+// manage their own connection - see statterNeedsRefresh.
+func StartRefresh(ctx context.Context, addr, prefix string, interval time.Duration) {
+	// Read straight from the package config, as the rest of the package does. Init
+	// writes it unguarded, so this is only safe in the documented order - after Init
+	// has returned - which is also the only order in which it makes sense to call.
+	cfg := config
+
+	if cfg == nil || cfg.MockingEnabled || !statterNeedsRefresh(cfg.Agent) {
+		return
+	}
+
+	if interval <= 0 {
+		interval = DefaultRefreshInterval
+	}
+
+	go startStatterRefresh(ctx, addr, prefix, cfg, interval)
+}
+
 type ServiceConfig struct {
 	Disabled             bool
 	ServiceName          string
@@ -248,6 +354,16 @@ type ServiceConfig struct {
 	OTelUseCounters      bool
 	TracingEnabled       bool
 	RetryInitialInterval time.Duration
+
+	// RefreshInterval is how often the UDP statsd client is rebuilt so it cannot be
+	// left holding a socket that no longer reaches the agent. See startStatterRefresh
+	// for why that happens and why nothing in the write path can detect it.
+	//
+	// Defaults to DefaultRefreshInterval. Set to a negative value to switch the
+	// refresh off entirely; it is on by default because the failure it prevents is
+	// silent, and a service that has stopped reporting looks exactly like a service
+	// with nothing to report.
+	RefreshInterval time.Duration
 }
 
 func (c ServiceConfig) normalizePrefix() string {
@@ -296,7 +412,20 @@ func InitService(ctx context.Context, cfg ServiceConfig) (func(timeout time.Dura
 		break
 	}
 
+	if refresh := cfg.refreshInterval(); refresh > 0 && !cfg.MockingEnabled && statterNeedsRefresh(cfg.AgentID) {
+		go startStatterRefresh(ctx, cfg.AgentAddress, cfg.normalizePrefix(), config, refresh)
+	}
+
 	return CloseWithTimeout, nil
+}
+
+// refreshInterval resolves the configured refresh cadence: unset means the default,
+// negative means the caller has deliberately turned it off.
+func (c ServiceConfig) refreshInterval() time.Duration {
+	if c.RefreshInterval == 0 {
+		return DefaultRefreshInterval
+	}
+	return c.RefreshInterval
 }
 
 func StartMixPanel(projectToken string) {

--- a/client.go
+++ b/client.go
@@ -49,6 +49,14 @@ var (
 	// the client the current Init put in place.
 	initGeneration atomic.Uint64
 
+	// generationSuperseded is closed when a later Init installs the next generation.
+	// The generation number alone is only checked once a rebuild is already in hand,
+	// so a superseded loop would otherwise sit on its ticker for a full interval -
+	// five minutes by default - and then dial the old destination once more before
+	// noticing it has been replaced. Closing the channel retires it at once. Guarded
+	// by clientMux together with the counter it tracks.
+	generationSuperseded = make(chan struct{})
+
 	traceProviderShutdownFn func(ctx context.Context) error
 	tracer                  trace.Tracer
 	mixPanelClient          *mixpanel.ApiClient
@@ -183,17 +191,56 @@ func Init(addr string, prefix string, cfg *StatterConfig) error {
 		return err
 	}
 
+	// Tracing and profiling can both fail, and a failed Init must leave the process
+	// reporting through whatever it was already using. So they run before the swap:
+	// until every step that can return an error has passed, the candidate statter is
+	// not published, and on failure it is closed rather than left holding a socket
+	// nobody will ever read from again.
+	if err := setupTracingFn(addr, prefix, cfg); err != nil {
+		_ = statter.Close()
+		return err
+	}
+
+	if cfg.Agent == DatadogAgent && cfg.ProfilingEnabled {
+		if err := setupProfiler(cfg); err != nil {
+			_ = statter.Close()
+			return err
+		}
+	}
+
 	swapStatter(statter, cfg)
 
+	if cfg.MixPanelEnabled {
+		StartMixPanel(cfg.MixPanelProjectToken)
+	}
+
+	return nil
+}
+
+// setupTracingFn is the tracing step Init runs. Indirected only so a test can fail
+// the step that comes after a successful statter build, which is the case that used
+// to throw away a working client.
+var setupTracingFn = setupTracing
+
+// setupTracing wires the process-global tracer provider for the configured agent.
+// Split out of Init so that everything able to fail sits in one place ahead of the
+// client swap; it is a no-op unless tracing is on for an agent that supports it.
+func setupTracing(addr, prefix string, cfg *StatterConfig) error {
+	if !cfg.TracingEnabled {
+		return nil
+	}
+
+	switch cfg.Agent {
 	// OpenTelemetry tracing via DataDog provider
-	if cfg.Agent == DatadogAgent && cfg.TracingEnabled {
+	case DatadogAgent:
 		traceProvider := ddotel.NewTracerProvider()
 		otel.SetTracerProvider(traceProvider)
 		tracer = otel.Tracer("")
 		traceProviderShutdownFn = func(_ context.Context) error {
 			return traceProvider.Shutdown()
 		}
-	} else if cfg.Agent == OTELAgent && cfg.TracingEnabled {
+
+	case OTELAgent:
 		traceProvider, err := newOTELTracerProvider(addr, cfg.OTELInsecure, cfg.OTELHeaders, cfg.BaseTags())
 		if err != nil {
 			return errors.Wrap(err, "otel tracer provider init failed")
@@ -207,17 +254,6 @@ func Init(addr string, prefix string, cfg *StatterConfig) error {
 		traceProviderShutdownFn = func(ctx context.Context) error {
 			return traceProvider.Shutdown(ctx)
 		}
-	}
-
-	if cfg.Agent == DatadogAgent && cfg.ProfilingEnabled {
-		err = setupProfiler(cfg)
-		if err != nil {
-			return err
-		}
-	}
-
-	if cfg.MixPanelEnabled {
-		StartMixPanel(cfg.MixPanelProjectToken)
 	}
 
 	return nil
@@ -286,20 +322,39 @@ func newStatter(addr, prefix string, cfg *StatterConfig) (Statter, error) {
 // flush goroutine on every re-init - harmless when Init ran once per process, a slow
 // leak now that the refresh loop swaps repeatedly.
 //
-// The returned generation is the one the caller's refresh loop should run under.
-func swapStatter(statter Statter, cfg *StatterConfig) uint64 {
+// The returned generation and channel are what the caller's refresh loop runs under:
+// the loop stops when the channel closes, which happens on the next swap.
+func swapStatter(statter Statter, cfg *StatterConfig) (uint64, <-chan struct{}) {
 	clientMux.Lock()
 	previous := client
 	client = statter
 	setCurrentConfig(cfg)
 	gen := initGeneration.Add(1)
+
+	// Retire the loops belonging to the generation being replaced, then hand the
+	// new one its own signal.
+	close(generationSuperseded)
+	generationSuperseded = make(chan struct{})
+	superseded := generationSuperseded
 	clientMux.Unlock()
 
 	if previous != nil {
 		_ = previous.Close()
 	}
 
-	return gen
+	return gen, superseded
+}
+
+// activeInit returns everything a refresh loop needs to be bound to one Init: the
+// config it should rebuild from, the generation that config was installed under, and
+// the channel closed when a later Init supersedes it. All three come out of a single
+// lock, so a loop can never be handed the config of one Init and the generation of
+// another - which would let it rebuild a stale destination that the generation check
+// then waves through as current.
+func activeInit() (*StatterConfig, uint64, <-chan struct{}) {
+	clientMux.RLock()
+	defer clientMux.RUnlock()
+	return currentConfig(), initGeneration.Load(), generationSuperseded
 }
 
 // refreshStatter installs a rebuilt statter, but only while gen is still the current
@@ -357,15 +412,19 @@ func statterNeedsRefresh(agent string) bool {
 // which flushes whatever it had buffered.
 //
 // The loop belongs to the Init generation named by gen and stops as soon as a later
-// Init supersedes it, so it can never put an earlier Init's destination or tag
-// format back in place.
-func startStatterRefresh(ctx context.Context, addr, prefix string, cfg *StatterConfig, interval time.Duration, gen uint64) {
+// Init supersedes it - immediately, on the superseded signal, rather than at the next
+// tick - so it can never put an earlier Init's destination or tag format back in
+// place, nor dial the old destination once more on its way out.
+func startStatterRefresh(ctx context.Context, addr, prefix string, cfg *StatterConfig, interval time.Duration, gen uint64, superseded <-chan struct{}) {
 	t := time.NewTicker(interval)
 	defer t.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
+			return
+		case <-superseded:
+			// A later Init owns the client now and started its own refresh for it.
 			return
 		case <-t.C:
 			statter, err := newStatter(addr, prefix, cfg)
@@ -377,8 +436,9 @@ func startStatterRefresh(ctx context.Context, addr, prefix string, cfg *StatterC
 				continue
 			}
 
+			// The generation check is still needed: an Init can land between the
+			// tick and the swap, after this loop has read the signal as open.
 			if !refreshStatter(statter, gen) {
-				// A later Init owns the client now, and started its own refresh for it.
 				return
 			}
 		}
@@ -397,22 +457,31 @@ func startStatterRefresh(ctx context.Context, addr, prefix string, cfg *StatterC
 // It is a no-op when Init has not run, when metrics are mocked, and for agents that
 // manage their own connection - see statterNeedsRefresh.
 func StartRefresh(ctx context.Context, addr, prefix string, interval time.Duration) {
-	// Read the config and the generation it was installed under together, so the loop
-	// is bound to the Init that actually produced the config it will rebuild from.
-	clientMux.RLock()
-	cfg := currentConfig()
-	gen := initGeneration.Load()
-	clientMux.RUnlock()
+	startRefresh(ctx, addr, prefix, interval)
+}
+
+// startRefresh is StartRefresh with a handle on the loop it starts: it returns a
+// channel closed once the loop has exited, or nil when there was no loop to start.
+// The tests join on it, so a rebuild can never land after the test that started it
+// has already reset the package globals.
+func startRefresh(ctx context.Context, addr, prefix string, interval time.Duration) <-chan struct{} {
+	cfg, gen, superseded := activeInit()
 
 	if cfg.Agent == "" || cfg.MockingEnabled || !statterNeedsRefresh(cfg.Agent) {
-		return
+		return nil
 	}
 
 	if interval <= 0 {
 		interval = DefaultRefreshInterval
 	}
 
-	go startStatterRefresh(ctx, addr, prefix, cfg, interval, gen)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		startStatterRefresh(ctx, addr, prefix, cfg, interval, gen, superseded)
+	}()
+
+	return done
 }
 
 type ServiceConfig struct {

--- a/client.go
+++ b/client.go
@@ -42,6 +42,13 @@ var (
 	// catches it immediately once a test does the same thing.
 	configPtr atomic.Pointer[StatterConfig]
 
+	// initGeneration counts the configurations Init has installed. A refresh loop is
+	// bound to the generation it was started for and retires itself as soon as a
+	// later Init installs another one - otherwise a loop left over from an earlier
+	// Init would keep rebuilding from its own address, prefix and tags and overwrite
+	// the client the current Init put in place.
+	initGeneration atomic.Uint64
+
 	traceProviderShutdownFn func(ctx context.Context) error
 	tracer                  trace.Tracer
 	mixPanelClient          *mixpanel.ApiClient
@@ -164,12 +171,10 @@ func Close() {
 
 func Init(addr string, prefix string, cfg *StatterConfig) error {
 	cfg = checkConfig(cfg)
-	setCurrentConfig(cfg)
+
 	if cfg.MockingEnabled {
 		// init a mock statter instead of real statsd client
-		clientMux.Lock()
-		client = newMockStatter(cfg)
-		clientMux.Unlock()
+		swapStatter(newMockStatter(cfg), cfg)
 		return nil
 	}
 
@@ -178,7 +183,7 @@ func Init(addr string, prefix string, cfg *StatterConfig) error {
 		return err
 	}
 
-	swapStatter(statter)
+	swapStatter(statter, cfg)
 
 	// OpenTelemetry tracing via DataDog provider
 	if cfg.Agent == DatadogAgent && cfg.TracingEnabled {
@@ -267,12 +272,49 @@ func newStatter(addr, prefix string, cfg *StatterConfig) (Statter, error) {
 	return statter, nil
 }
 
-// swapStatter installs a new statter and closes the one it replaces. Init used to
-// overwrite the package-level client without closing it, which leaked the old
-// client's socket and flush goroutine on every re-init - harmless when Init ran
-// once per process, a slow leak now that the refresh loop calls it repeatedly.
-func swapStatter(statter Statter) {
+// swapStatter installs a statter built by Init, publishing the config it was built
+// from in the same critical section and closing the statter it replaces.
+//
+// Client and config go in together because the reporting path reads both under one
+// clientMux.RLock - JoinTags picks the tag format out of the config - so publishing
+// the config first would let a report format Telegraf tags for a Datadog client
+// that has not been replaced yet, and would leave that mismatch behind for good if
+// construction then failed.
+//
+// Closing the replaced statter matters too: Init used to overwrite the
+// package-level client without closing it, which leaked the old client's socket and
+// flush goroutine on every re-init - harmless when Init ran once per process, a slow
+// leak now that the refresh loop swaps repeatedly.
+//
+// The returned generation is the one the caller's refresh loop should run under.
+func swapStatter(statter Statter, cfg *StatterConfig) uint64 {
 	clientMux.Lock()
+	previous := client
+	client = statter
+	setCurrentConfig(cfg)
+	gen := initGeneration.Add(1)
+	clientMux.Unlock()
+
+	if previous != nil {
+		_ = previous.Close()
+	}
+
+	return gen
+}
+
+// refreshStatter installs a rebuilt statter, but only while gen is still the current
+// generation. A refresh loop holds the addr, prefix and config of the Init that
+// started it; if a later Init has since installed different ones, letting this swap
+// through would put the older Init's destination and tag format back in place. It
+// reports false when that has happened, which is the loop's signal to stop.
+func refreshStatter(statter Statter, gen uint64) bool {
+	clientMux.Lock()
+	if initGeneration.Load() != gen {
+		clientMux.Unlock()
+		_ = statter.Close()
+		return false
+	}
+
 	previous := client
 	client = statter
 	clientMux.Unlock()
@@ -280,6 +322,8 @@ func swapStatter(statter Statter) {
 	if previous != nil {
 		_ = previous.Close()
 	}
+
+	return true
 }
 
 // statterNeedsRefresh reports whether this agent talks over a connectionless
@@ -311,7 +355,11 @@ func statterNeedsRefresh(agent string) bool {
 // only the pod behind it. Rebuilding the socket is what recovers, so that is what
 // this does. It is cheap - a UDP dial, no handshake - and the old client is closed,
 // which flushes whatever it had buffered.
-func startStatterRefresh(ctx context.Context, addr, prefix string, cfg *StatterConfig, interval time.Duration) {
+//
+// The loop belongs to the Init generation named by gen and stops as soon as a later
+// Init supersedes it, so it can never put an earlier Init's destination or tag
+// format back in place.
+func startStatterRefresh(ctx context.Context, addr, prefix string, cfg *StatterConfig, interval time.Duration, gen uint64) {
 	t := time.NewTicker(interval)
 	defer t.Stop()
 
@@ -329,7 +377,10 @@ func startStatterRefresh(ctx context.Context, addr, prefix string, cfg *StatterC
 				continue
 			}
 
-			swapStatter(statter)
+			if !refreshStatter(statter, gen) {
+				// A later Init owns the client now, and started its own refresh for it.
+				return
+			}
 		}
 	}
 }
@@ -346,7 +397,12 @@ func startStatterRefresh(ctx context.Context, addr, prefix string, cfg *StatterC
 // It is a no-op when Init has not run, when metrics are mocked, and for agents that
 // manage their own connection - see statterNeedsRefresh.
 func StartRefresh(ctx context.Context, addr, prefix string, interval time.Duration) {
+	// Read the config and the generation it was installed under together, so the loop
+	// is bound to the Init that actually produced the config it will rebuild from.
+	clientMux.RLock()
 	cfg := currentConfig()
+	gen := initGeneration.Load()
+	clientMux.RUnlock()
 
 	if cfg.Agent == "" || cfg.MockingEnabled || !statterNeedsRefresh(cfg.Agent) {
 		return
@@ -356,7 +412,7 @@ func StartRefresh(ctx context.Context, addr, prefix string, interval time.Durati
 		interval = DefaultRefreshInterval
 	}
 
-	go startStatterRefresh(ctx, addr, prefix, cfg, interval)
+	go startStatterRefresh(ctx, addr, prefix, cfg, interval, gen)
 }
 
 type ServiceConfig struct {
@@ -432,8 +488,8 @@ func InitService(ctx context.Context, cfg ServiceConfig) (func(timeout time.Dura
 		break
 	}
 
-	if refresh := cfg.refreshInterval(); refresh > 0 && !cfg.MockingEnabled && statterNeedsRefresh(cfg.AgentID) {
-		go startStatterRefresh(ctx, cfg.AgentAddress, cfg.normalizePrefix(), currentConfig(), refresh)
+	if refresh := cfg.refreshInterval(); refresh > 0 {
+		StartRefresh(ctx, cfg.AgentAddress, cfg.normalizePrefix(), refresh)
 	}
 
 	return CloseWithTimeout, nil

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	dogstatsd "github.com/DataDog/datadog-go/v5/statsd"
@@ -32,12 +33,33 @@ var (
 
 	client    Statter
 	clientMux = new(sync.RWMutex)
-	config    *StatterConfig
+
+	// configPtr holds the active StatterConfig. Init used to assign a package-level
+	// variable with no synchronisation at all, while every reporting call read it -
+	// JoinTags and the stuck-function timers do so on the hot path. Services that
+	// initialise metrics on a goroutine (a retry loop around Init is the common
+	// shape) therefore raced Init against their own first reports; `go test -race`
+	// catches it immediately once a test does the same thing.
+	configPtr atomic.Pointer[StatterConfig]
 
 	traceProviderShutdownFn func(ctx context.Context) error
 	tracer                  trace.Tracer
 	mixPanelClient          *mixpanel.ApiClient
 )
+
+// currentConfig returns the active config, or an empty one when Init has not run.
+// Returning a zero value rather than nil keeps a report that arrives before Init
+// harmless, which is the same thing the nil-client check does one level up.
+func currentConfig() *StatterConfig {
+	if cfg := configPtr.Load(); cfg != nil {
+		return cfg
+	}
+	return &StatterConfig{}
+}
+
+func setCurrentConfig(cfg *StatterConfig) {
+	configPtr.Store(cfg)
+}
 
 type StatterConfig struct {
 	Addr                   string            // localhost:8125
@@ -67,32 +89,32 @@ func (m *StatterConfig) BaseTags() []string {
 	switch m.Agent {
 
 	case DatadogAgent:
-		if len(config.EnvName) > 0 {
-			baseTags = append(baseTags, "env:"+config.EnvName)
+		if len(m.EnvName) > 0 {
+			baseTags = append(baseTags, "env:"+m.EnvName)
 		}
-		if len(config.HostName) > 0 {
-			baseTags = append(baseTags, "machine:"+config.HostName)
+		if len(m.HostName) > 0 {
+			baseTags = append(baseTags, "machine:"+m.HostName)
 		}
 		for k, v := range defaultTags {
 			baseTags = append(baseTags, k+":"+v)
 		}
 	case OTELAgent:
-		if len(config.EnvName) > 0 {
-			baseTags = append(baseTags, "env="+config.EnvName)
+		if len(m.EnvName) > 0 {
+			baseTags = append(baseTags, "env="+m.EnvName)
 		}
-		if len(config.HostName) > 0 {
-			baseTags = append(baseTags, "machine="+config.HostName)
+		if len(m.HostName) > 0 {
+			baseTags = append(baseTags, "machine="+m.HostName)
 		}
 		for k, v := range defaultTags {
 			baseTags = append(baseTags, k+"="+v)
 		}
 	// telegraf by default
 	default:
-		if len(config.EnvName) > 0 {
-			baseTags = append(baseTags, "env", config.EnvName)
+		if len(m.EnvName) > 0 {
+			baseTags = append(baseTags, "env", m.EnvName)
 		}
-		if len(config.HostName) > 0 {
-			baseTags = append(baseTags, "machine", config.HostName)
+		if len(m.HostName) > 0 {
+			baseTags = append(baseTags, "machine", m.HostName)
 		}
 		for k, v := range defaultTags {
 			baseTags = append(baseTags, k, v)
@@ -141,8 +163,9 @@ func Close() {
 }
 
 func Init(addr string, prefix string, cfg *StatterConfig) error {
-	config = checkConfig(cfg)
-	if config.MockingEnabled {
+	cfg = checkConfig(cfg)
+	setCurrentConfig(cfg)
+	if cfg.MockingEnabled {
 		// init a mock statter instead of real statsd client
 		clientMux.Lock()
 		client = newMockStatter(cfg)
@@ -166,7 +189,7 @@ func Init(addr string, prefix string, cfg *StatterConfig) error {
 			return traceProvider.Shutdown()
 		}
 	} else if cfg.Agent == OTELAgent && cfg.TracingEnabled {
-		traceProvider, err := newOTELTracerProvider(addr, cfg.OTELInsecure, cfg.OTELHeaders, config.BaseTags())
+		traceProvider, err := newOTELTracerProvider(addr, cfg.OTELInsecure, cfg.OTELHeaders, cfg.BaseTags())
 		if err != nil {
 			return errors.Wrap(err, "otel tracer provider init failed")
 		}
@@ -211,7 +234,7 @@ func newStatter(addr, prefix string, cfg *StatterConfig) (Statter, error) {
 			addr,
 			dogstatsd.WithNamespace(prefix),
 			dogstatsd.WithWriteTimeout(time.Duration(10)*time.Second),
-			dogstatsd.WithTags(config.BaseTags()),
+			dogstatsd.WithTags(cfg.BaseTags()),
 		)
 
 	case TelegrafAgent:
@@ -220,7 +243,7 @@ func newStatter(addr, prefix string, cfg *StatterConfig) (Statter, error) {
 			statsd.Prefix(prefix),
 			statsd.ErrorHandler(errHandler),
 			statsd.TagsFormat(statsd.InfluxDB),
-			statsd.Tags(config.BaseTags()...),
+			statsd.Tags(cfg.BaseTags()...),
 		)
 
 	case OTELAgent:
@@ -229,7 +252,7 @@ func newStatter(addr, prefix string, cfg *StatterConfig) (Statter, error) {
 			prefix,
 			cfg.OTELInsecure,
 			cfg.OTELHeaders,
-			config.BaseTags(),
+			cfg.BaseTags(),
 			cfg.OTELUseCounterForCount,
 		)
 
@@ -323,12 +346,9 @@ func startStatterRefresh(ctx context.Context, addr, prefix string, cfg *StatterC
 // It is a no-op when Init has not run, when metrics are mocked, and for agents that
 // manage their own connection - see statterNeedsRefresh.
 func StartRefresh(ctx context.Context, addr, prefix string, interval time.Duration) {
-	// Read straight from the package config, as the rest of the package does. Init
-	// writes it unguarded, so this is only safe in the documented order - after Init
-	// has returned - which is also the only order in which it makes sense to call.
-	cfg := config
+	cfg := currentConfig()
 
-	if cfg == nil || cfg.MockingEnabled || !statterNeedsRefresh(cfg.Agent) {
+	if cfg.Agent == "" || cfg.MockingEnabled || !statterNeedsRefresh(cfg.Agent) {
 		return
 	}
 
@@ -413,7 +433,7 @@ func InitService(ctx context.Context, cfg ServiceConfig) (func(timeout time.Dura
 	}
 
 	if refresh := cfg.refreshInterval(); refresh > 0 && !cfg.MockingEnabled && statterNeedsRefresh(cfg.AgentID) {
-		go startStatterRefresh(ctx, cfg.AgentAddress, cfg.normalizePrefix(), config, refresh)
+		go startStatterRefresh(ctx, cfg.AgentAddress, cfg.normalizePrefix(), currentConfig(), refresh)
 	}
 
 	return CloseWithTimeout, nil

--- a/client_test.go
+++ b/client_test.go
@@ -54,6 +54,31 @@ func resetClientGlobals(t *testing.T) {
 	})
 }
 
+// runRefresh starts a refresh loop for the generation currently installed and, on
+// cleanup, cancels it and waits for it to actually exit.
+//
+// The waiting is the point: cancel() does not abandon a tick the loop has already
+// selected, so without the join a swap can land after the test returns and replace
+// the package client while the next test is asserting on it. Call it after
+// resetClientGlobals so that this cleanup, being registered later, runs first.
+func runRefresh(t *testing.T, addr, prefix string, cfg *StatterConfig, interval time.Duration) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	gen := initGeneration.Load()
+
+	go func() {
+		startStatterRefresh(ctx, addr, prefix, cfg, interval, gen)
+		close(done)
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+}
+
 func TestBaseTags(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -134,11 +159,11 @@ func TestSwapStatterClosesReplacedClient(t *testing.T) {
 	first := &countingStatter{}
 	second := &countingStatter{}
 
-	swapStatter(first)
+	swapStatter(first, &StatterConfig{Agent: TelegrafAgent})
 	assert.Same(t, first, currentClient())
 	assert.Equal(t, 0, first.closeCount(), "installing the first client must not close it")
 
-	swapStatter(second)
+	swapStatter(second, &StatterConfig{Agent: TelegrafAgent})
 	assert.Same(t, second, currentClient(), "the new client must be the one in use")
 	assert.Equal(t, 1, first.closeCount(), "the replaced client must be closed, or its socket leaks")
 	assert.Equal(t, 0, second.closeCount())
@@ -148,7 +173,7 @@ func TestSwapStatterFromEmpty(t *testing.T) {
 	resetClientGlobals(t)
 
 	// The very first swap has nothing to close and must not panic on the nil client.
-	assert.NotPanics(t, func() { swapStatter(&countingStatter{}) })
+	assert.NotPanics(t, func() { swapStatter(&countingStatter{}, &StatterConfig{Agent: TelegrafAgent}) })
 }
 
 func TestStatterNeedsRefresh(t *testing.T) {
@@ -192,15 +217,11 @@ func TestStartStatterRefreshRebuildsAndClosesTheOldClient(t *testing.T) {
 	resetClientGlobals(t)
 
 	cfg := &StatterConfig{Agent: DatadogAgent, EnvName: "test", HostName: "host"}
-	setCurrentConfig(cfg)
 
 	initial := &countingStatter{}
-	swapStatter(initial)
+	swapStatter(initial, cfg)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go startStatterRefresh(ctx, "127.0.0.1:8125", "test.", cfg, 20*time.Millisecond)
+	runRefresh(t, "127.0.0.1:8125", "test.", cfg, 20*time.Millisecond)
 
 	// The refresh must replace the client it found in place, and close it on the way
 	// out - that swap is the whole point: a socket that no longer reaches the agent
@@ -222,7 +243,7 @@ func TestStartStatterRefreshStopsOnContextCancel(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		startStatterRefresh(ctx, "127.0.0.1:8125", "test.", cfg, time.Hour)
+		startStatterRefresh(ctx, "127.0.0.1:8125", "test.", cfg, time.Hour, initGeneration.Load())
 		close(done)
 	}()
 
@@ -242,15 +263,11 @@ func TestStartStatterRefreshKeepsClientWhenRebuildFails(t *testing.T) {
 	// has to survive that: a client that might still work beats a nil one, which
 	// drops every metric silently.
 	cfg := &StatterConfig{Agent: "nonexistent-agent"}
-	setCurrentConfig(cfg)
 
 	initial := &countingStatter{}
-	swapStatter(initial)
+	swapStatter(initial, cfg)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go startStatterRefresh(ctx, "127.0.0.1:8125", "test.", cfg, 10*time.Millisecond)
+	runRefresh(t, "127.0.0.1:8125", "test.", cfg, 10*time.Millisecond)
 
 	time.Sleep(150 * time.Millisecond)
 
@@ -271,10 +288,9 @@ func TestStartRefreshIsANoOpWhenItCannotHelp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resetClientGlobals(t)
-			setCurrentConfig(tt.cfg)
 
 			initial := &countingStatter{}
-			swapStatter(initial)
+			swapStatter(initial, tt.cfg)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -290,10 +306,9 @@ func TestStartRefreshIsANoOpWhenItCannotHelp(t *testing.T) {
 
 func TestStartRefreshRebuildsForUDPAgents(t *testing.T) {
 	resetClientGlobals(t)
-	setCurrentConfig(&StatterConfig{Agent: DatadogAgent, EnvName: "test", HostName: "host"})
 
 	initial := &countingStatter{}
-	swapStatter(initial)
+	swapStatter(initial, &StatterConfig{Agent: DatadogAgent, EnvName: "test", HostName: "host"})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -323,11 +338,14 @@ func TestInitConcurrentWithReporting_IsRaceFree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bind sink: %v", err)
 	}
-	defer sink.Close()
+	t.Cleanup(func() {
+		if err := sink.Close(); err != nil {
+			t.Errorf("close UDP sink: %v", err)
+		}
+	})
 	addr := sink.LocalAddr().String()
 
-	setCurrentConfig(&StatterConfig{Agent: TelegrafAgent, EnvName: "test", HostName: "host"})
-	swapStatter(&countingStatter{})
+	swapStatter(&countingStatter{}, &StatterConfig{Agent: TelegrafAgent, EnvName: "test", HostName: "host"})
 
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
@@ -361,4 +379,69 @@ func TestInitConcurrentWithReporting_IsRaceFree(t *testing.T) {
 
 	close(stop)
 	wg.Wait()
+}
+
+// A refresh loop outlives the Init that started it only until the next Init. Without
+// the generation guard, a loop left over from an earlier Init keeps rebuilding from
+// its own address, prefix and tags, and the first tick after a re-init hands the
+// process a client pointed at the previous destination with the previous tag format.
+func TestRefreshFromASupersededInitRetiresItself(t *testing.T) {
+	resetClientGlobals(t)
+
+	staleCfg := &StatterConfig{Agent: DatadogAgent, EnvName: "test", HostName: "host"}
+	staleGen := swapStatter(&countingStatter{}, staleCfg)
+
+	// A later Init: different destination, different agent, new generation.
+	currentCfg := &StatterConfig{Agent: TelegrafAgent, EnvName: "test", HostName: "host"}
+	current := &countingStatter{}
+	swapStatter(current, currentCfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		startStatterRefresh(ctx, "127.0.0.1:8125", "stale.", staleCfg, 10*time.Millisecond, staleGen)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("a superseded refresh loop must stop on its own, not keep swapping")
+	}
+
+	assert.Same(t, current, currentClient(), "a stale refresh must not replace what a later Init installed")
+	assert.Equal(t, 0, current.closeCount(), "the live client must not be closed by a stale refresh")
+	assert.Equal(t, TelegrafAgent, currentConfig().Agent, "a stale refresh must not restore the older config")
+}
+
+func TestInitClosesThePreviousClientWhenSwitchingToMocking(t *testing.T) {
+	resetClientGlobals(t)
+
+	previous := &countingStatter{}
+	swapStatter(previous, &StatterConfig{Agent: TelegrafAgent})
+
+	require.NoError(t, Init("127.0.0.1:8125", "test.", &StatterConfig{
+		Agent: TelegrafAgent, MockingEnabled: true,
+	}))
+
+	assert.NotSame(t, previous, currentClient(), "mocking must take over the client")
+	assert.Equal(t, 1, previous.closeCount(), "switching to mocking must close the real client, or its socket leaks")
+}
+
+// The config is what JoinTags reads to pick the tag format, so publishing it before
+// the client it belongs to would have reports formatting tags for a client that does
+// not exist yet - and would leave that mismatch in place for good if the build failed.
+func TestInitLeavesTheWorkingClientAndItsConfigWhenConstructionFails(t *testing.T) {
+	resetClientGlobals(t)
+
+	working := &countingStatter{}
+	swapStatter(working, &StatterConfig{Agent: TelegrafAgent, EnvName: "test", HostName: "host"})
+
+	require.Error(t, Init("127.0.0.1:8125", "test.", &StatterConfig{Agent: "nonexistent-agent"}))
+
+	assert.Same(t, working, currentClient(), "a failed Init must leave the working client in place")
+	assert.Equal(t, 0, working.closeCount())
+	assert.Equal(t, TelegrafAgent, currentConfig().Agent, "a failed Init must not publish the config it could not build")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,10 +1,57 @@
 package metrics
 
 import (
+	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// countingStatter records that it was closed, so the tests can assert the refresh
+// path does not leak the client it replaces.
+type countingStatter struct {
+	mux    sync.Mutex
+	closed int
+}
+
+func (s *countingStatter) Count(string, int64, []string, float64) error          { return nil }
+func (s *countingStatter) Incr(string, []string, float64) error                  { return nil }
+func (s *countingStatter) Decr(string, []string, float64) error                  { return nil }
+func (s *countingStatter) Gauge(string, float64, []string, float64) error        { return nil }
+func (s *countingStatter) Timing(string, time.Duration, []string, float64) error { return nil }
+func (s *countingStatter) Histogram(string, float64, []string, float64) error    { return nil }
+
+func (s *countingStatter) Close() error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	s.closed++
+	return nil
+}
+
+func (s *countingStatter) closeCount() int {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	return s.closed
+}
+
+func currentClient() Statter {
+	clientMux.RLock()
+	defer clientMux.RUnlock()
+	return client
+}
+
+func resetClientGlobals(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		clientMux.Lock()
+		client = nil
+		clientMux.Unlock()
+		config = nil
+	})
+}
 
 func TestBaseTags(t *testing.T) {
 	tests := []struct {
@@ -78,4 +125,183 @@ func TestBaseTags(t *testing.T) {
 			assert.ElementsMatch(t, tt.expected, result)
 		})
 	}
+}
+
+func TestSwapStatterClosesReplacedClient(t *testing.T) {
+	resetClientGlobals(t)
+
+	first := &countingStatter{}
+	second := &countingStatter{}
+
+	swapStatter(first)
+	assert.Same(t, first, currentClient())
+	assert.Equal(t, 0, first.closeCount(), "installing the first client must not close it")
+
+	swapStatter(second)
+	assert.Same(t, second, currentClient(), "the new client must be the one in use")
+	assert.Equal(t, 1, first.closeCount(), "the replaced client must be closed, or its socket leaks")
+	assert.Equal(t, 0, second.closeCount())
+}
+
+func TestSwapStatterFromEmpty(t *testing.T) {
+	resetClientGlobals(t)
+
+	// The very first swap has nothing to close and must not panic on the nil client.
+	assert.NotPanics(t, func() { swapStatter(&countingStatter{}) })
+}
+
+func TestStatterNeedsRefresh(t *testing.T) {
+	tests := []struct {
+		agent    string
+		expected bool
+		why      string
+	}{
+		{DatadogAgent, true, "UDP socket, dialed once, cannot detect that delivery stopped"},
+		{TelegrafAgent, true, "same connectionless UDP path as datadog"},
+		{OTELAgent, false, "gRPC/HTTP exporter redials on its own; rebuilding it would drop batches"},
+		{"", false, "unknown agents are left alone"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.agent, func(t *testing.T) {
+			assert.Equal(t, tt.expected, statterNeedsRefresh(tt.agent), tt.why)
+		})
+	}
+}
+
+func TestServiceConfigRefreshInterval(t *testing.T) {
+	tests := []struct {
+		name     string
+		set      time.Duration
+		expected time.Duration
+	}{
+		{"unset falls back to the default", 0, DefaultRefreshInterval},
+		{"explicit interval is honoured", 30 * time.Second, 30 * time.Second},
+		{"negative disables the refresh", -1, -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ServiceConfig{RefreshInterval: tt.set}.refreshInterval())
+		})
+	}
+}
+
+func TestStartStatterRefreshRebuildsAndClosesTheOldClient(t *testing.T) {
+	resetClientGlobals(t)
+
+	cfg := &StatterConfig{Agent: DatadogAgent, EnvName: "test", HostName: "host"}
+	config = cfg
+
+	initial := &countingStatter{}
+	swapStatter(initial)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go startStatterRefresh(ctx, "127.0.0.1:8125", "test.", cfg, 20*time.Millisecond)
+
+	// The refresh must replace the client it found in place, and close it on the way
+	// out - that swap is the whole point: a socket that no longer reaches the agent
+	// is indistinguishable, from inside the process, from one that does.
+	require.Eventually(t, func() bool {
+		return currentClient() != Statter(initial)
+	}, 3*time.Second, 10*time.Millisecond, "refresh loop never replaced the client")
+
+	assert.Equal(t, 1, initial.closeCount(), "the replaced client must be closed")
+}
+
+func TestStartStatterRefreshStopsOnContextCancel(t *testing.T) {
+	resetClientGlobals(t)
+
+	cfg := &StatterConfig{Agent: DatadogAgent, EnvName: "test", HostName: "host"}
+	config = cfg
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		startStatterRefresh(ctx, "127.0.0.1:8125", "test.", cfg, time.Hour)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("refresh loop outlived its context")
+	}
+}
+
+func TestStartStatterRefreshKeepsClientWhenRebuildFails(t *testing.T) {
+	resetClientGlobals(t)
+
+	// An unsupported agent makes newStatter fail on every tick. The existing client
+	// has to survive that: a client that might still work beats a nil one, which
+	// drops every metric silently.
+	cfg := &StatterConfig{Agent: "nonexistent-agent"}
+	config = cfg
+
+	initial := &countingStatter{}
+	swapStatter(initial)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go startStatterRefresh(ctx, "127.0.0.1:8125", "test.", cfg, 10*time.Millisecond)
+
+	time.Sleep(150 * time.Millisecond)
+
+	assert.Same(t, initial, currentClient(), "a failed rebuild must leave the working client in place")
+	assert.Equal(t, 0, initial.closeCount(), "a failed rebuild must not close the client still in use")
+}
+
+func TestStartRefreshIsANoOpWhenItCannotHelp(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *StatterConfig
+	}{
+		{"Init has not run", nil},
+		{"metrics are mocked", &StatterConfig{Agent: DatadogAgent, MockingEnabled: true}},
+		{"agent manages its own connection", &StatterConfig{Agent: OTELAgent}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetClientGlobals(t)
+			config = tt.cfg
+
+			initial := &countingStatter{}
+			swapStatter(initial)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			StartRefresh(ctx, "127.0.0.1:8125", "test.", 10*time.Millisecond)
+			time.Sleep(120 * time.Millisecond)
+
+			assert.Same(t, initial, currentClient(), "no refresh loop should have started")
+			assert.Equal(t, 0, initial.closeCount())
+		})
+	}
+}
+
+func TestStartRefreshRebuildsForUDPAgents(t *testing.T) {
+	resetClientGlobals(t)
+	config = &StatterConfig{Agent: DatadogAgent, EnvName: "test", HostName: "host"}
+
+	initial := &countingStatter{}
+	swapStatter(initial)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	StartRefresh(ctx, "127.0.0.1:8125", "test.", 20*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return currentClient() != Statter(initial)
+	}, 3*time.Second, 10*time.Millisecond, "StartRefresh never rebuilt the client")
+
+	assert.Equal(t, 1, initial.closeCount())
 }

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -49,7 +50,7 @@ func resetClientGlobals(t *testing.T) {
 		clientMux.Lock()
 		client = nil
 		clientMux.Unlock()
-		config = nil
+		setCurrentConfig(nil)
 	})
 }
 
@@ -118,9 +119,9 @@ func TestBaseTags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Cleanup(func() {
-				config = nil
+				setCurrentConfig(nil)
 			})
-			config = tt.config
+			setCurrentConfig(tt.config)
 			result := tt.config.BaseTags()
 			assert.ElementsMatch(t, tt.expected, result)
 		})
@@ -191,7 +192,7 @@ func TestStartStatterRefreshRebuildsAndClosesTheOldClient(t *testing.T) {
 	resetClientGlobals(t)
 
 	cfg := &StatterConfig{Agent: DatadogAgent, EnvName: "test", HostName: "host"}
-	config = cfg
+	setCurrentConfig(cfg)
 
 	initial := &countingStatter{}
 	swapStatter(initial)
@@ -215,7 +216,7 @@ func TestStartStatterRefreshStopsOnContextCancel(t *testing.T) {
 	resetClientGlobals(t)
 
 	cfg := &StatterConfig{Agent: DatadogAgent, EnvName: "test", HostName: "host"}
-	config = cfg
+	setCurrentConfig(cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -241,7 +242,7 @@ func TestStartStatterRefreshKeepsClientWhenRebuildFails(t *testing.T) {
 	// has to survive that: a client that might still work beats a nil one, which
 	// drops every metric silently.
 	cfg := &StatterConfig{Agent: "nonexistent-agent"}
-	config = cfg
+	setCurrentConfig(cfg)
 
 	initial := &countingStatter{}
 	swapStatter(initial)
@@ -270,7 +271,7 @@ func TestStartRefreshIsANoOpWhenItCannotHelp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resetClientGlobals(t)
-			config = tt.cfg
+			setCurrentConfig(tt.cfg)
 
 			initial := &countingStatter{}
 			swapStatter(initial)
@@ -289,7 +290,7 @@ func TestStartRefreshIsANoOpWhenItCannotHelp(t *testing.T) {
 
 func TestStartRefreshRebuildsForUDPAgents(t *testing.T) {
 	resetClientGlobals(t)
-	config = &StatterConfig{Agent: DatadogAgent, EnvName: "test", HostName: "host"}
+	setCurrentConfig(&StatterConfig{Agent: DatadogAgent, EnvName: "test", HostName: "host"})
 
 	initial := &countingStatter{}
 	swapStatter(initial)
@@ -304,4 +305,60 @@ func TestStartRefreshRebuildsForUDPAgents(t *testing.T) {
 	}, 3*time.Second, 10*time.Millisecond, "StartRefresh never rebuilt the client")
 
 	assert.Equal(t, 1, initial.closeCount())
+}
+
+// Init used to assign the package-level config with no synchronisation while every
+// reporting call read it - JoinTags and the stuck-function timers do so on the hot
+// path. Any service that initialises metrics on a goroutine, which is the usual shape
+// when Init is wrapped in a retry loop, was racing its own first reports.
+//
+// This reproduces that shape: report continuously while Init runs underneath. It is
+// only meaningful under -race, where it fails outright before the fix.
+func TestInitConcurrentWithReporting_IsRaceFree(t *testing.T) {
+	resetClientGlobals(t)
+
+	// A real socket, so the statter is not logging a write error per report and the
+	// test is measuring the config access rather than the failure path.
+	sink, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("bind sink: %v", err)
+	}
+	defer sink.Close()
+	addr := sink.LocalAddr().String()
+
+	setCurrentConfig(&StatterConfig{Agent: TelegrafAgent, EnvName: "test", HostName: "host"})
+	swapStatter(&countingStatter{})
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Readers: the reporting path, hammering the config through JoinTags.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				CustomReport(func(s Statter, tagSpec []string) {
+					_ = s.Gauge("probe", 1, tagSpec, 1)
+				}, Tags{"svc": "test"})
+			}
+		}()
+	}
+
+	// Writer: repeated Init, as a retry loop or a re-init would do.
+	for i := 0; i < 50; i++ {
+		if err := Init(addr, "racetest.", &StatterConfig{
+			Agent: TelegrafAgent, EnvName: "test", HostName: "host",
+		}); err != nil {
+			t.Fatalf("init: %v", err)
+		}
+	}
+
+	close(stop)
+	wg.Wait()
 }

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"net"
 	"sync"
 	"testing"
@@ -66,12 +67,28 @@ func runRefresh(t *testing.T, addr, prefix string, cfg *StatterConfig, interval 
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	gen := initGeneration.Load()
+	_, gen, superseded := activeInit()
 
 	go func() {
-		startStatterRefresh(ctx, addr, prefix, cfg, interval, gen)
+		startStatterRefresh(ctx, addr, prefix, cfg, interval, gen, superseded)
 		close(done)
 	}()
+
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+}
+
+// joinRefresh runs the public StartRefresh path and, on cleanup, cancels the loop and
+// waits for it to exit - the same join runRefresh does, and for the same reason.
+// It fails the test if no loop was started. Call it after resetClientGlobals.
+func joinRefresh(t *testing.T, addr, prefix string, interval time.Duration) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startRefresh(ctx, addr, prefix, interval)
+	require.NotNil(t, done, "a refresh loop should have started")
 
 	t.Cleanup(func() {
 		cancel()
@@ -241,9 +258,10 @@ func TestStartStatterRefreshStopsOnContextCancel(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	_, gen, superseded := activeInit()
 	done := make(chan struct{})
 	go func() {
-		startStatterRefresh(ctx, "127.0.0.1:8125", "test.", cfg, time.Hour, initGeneration.Load())
+		startStatterRefresh(ctx, "127.0.0.1:8125", "test.", cfg, time.Hour, gen, superseded)
 		close(done)
 	}()
 
@@ -295,10 +313,9 @@ func TestStartRefreshIsANoOpWhenItCannotHelp(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			StartRefresh(ctx, "127.0.0.1:8125", "test.", 10*time.Millisecond)
-			time.Sleep(120 * time.Millisecond)
-
-			assert.Same(t, initial, currentClient(), "no refresh loop should have started")
+			assert.Nil(t, startRefresh(ctx, "127.0.0.1:8125", "test.", 10*time.Millisecond),
+				"no refresh loop should have started")
+			assert.Same(t, initial, currentClient())
 			assert.Equal(t, 0, initial.closeCount())
 		})
 	}
@@ -310,10 +327,7 @@ func TestStartRefreshRebuildsForUDPAgents(t *testing.T) {
 	initial := &countingStatter{}
 	swapStatter(initial, &StatterConfig{Agent: DatadogAgent, EnvName: "test", HostName: "host"})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	StartRefresh(ctx, "127.0.0.1:8125", "test.", 20*time.Millisecond)
+	joinRefresh(t, "127.0.0.1:8125", "test.", 20*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		return currentClient() != Statter(initial)
@@ -389,7 +403,7 @@ func TestRefreshFromASupersededInitRetiresItself(t *testing.T) {
 	resetClientGlobals(t)
 
 	staleCfg := &StatterConfig{Agent: DatadogAgent, EnvName: "test", HostName: "host"}
-	staleGen := swapStatter(&countingStatter{}, staleCfg)
+	staleGen, staleSuperseded := swapStatter(&countingStatter{}, staleCfg)
 
 	// A later Init: different destination, different agent, new generation.
 	currentCfg := &StatterConfig{Agent: TelegrafAgent, EnvName: "test", HostName: "host"}
@@ -401,19 +415,46 @@ func TestRefreshFromASupersededInitRetiresItself(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		startStatterRefresh(ctx, "127.0.0.1:8125", "stale.", staleCfg, 10*time.Millisecond, staleGen)
+		startStatterRefresh(ctx, "127.0.0.1:8125", "stale.", staleCfg, time.Hour, staleGen, staleSuperseded)
 		close(done)
 	}()
 
+	// The interval is an hour: a loop that only noticed on its ticker would still be
+	// sitting there, holding the previous destination and tag format, long after the
+	// Init that replaced it returned.
 	select {
 	case <-done:
 	case <-time.After(3 * time.Second):
-		t.Fatal("a superseded refresh loop must stop on its own, not keep swapping")
+		t.Fatal("a superseded refresh loop must retire at once, not wait out its interval")
 	}
 
 	assert.Same(t, current, currentClient(), "a stale refresh must not replace what a later Init installed")
 	assert.Equal(t, 0, current.closeCount(), "the live client must not be closed by a stale refresh")
 	assert.Equal(t, TelegrafAgent, currentConfig().Agent, "a stale refresh must not restore the older config")
+}
+
+// Init used to publish the new client before tracing and profiling setup, both of
+// which can fail. A failure then returned an error having already closed the client
+// the process was reporting through, and left the new config published behind it.
+func TestInitKeepsTheWorkingClientWhenSetupAfterTheSwapFails(t *testing.T) {
+	resetClientGlobals(t)
+
+	working := &countingStatter{}
+	swapStatter(working, &StatterConfig{Agent: TelegrafAgent, EnvName: "test", HostName: "host"})
+
+	original := setupTracingFn
+	t.Cleanup(func() { setupTracingFn = original })
+	setupTracingFn = func(string, string, *StatterConfig) error {
+		return errors.New("tracer provider init failed")
+	}
+
+	require.Error(t, Init("127.0.0.1:8125", "new.", &StatterConfig{
+		Agent: DatadogAgent, EnvName: "new", HostName: "host", TracingEnabled: true,
+	}))
+
+	assert.Same(t, working, currentClient(), "a failed Init must leave the working client in place")
+	assert.Equal(t, 0, working.closeCount(), "the working client must not be closed by an Init that failed")
+	assert.Equal(t, TelegrafAgent, currentConfig().Agent, "a failed Init must not publish its config")
 }
 
 func TestInitClosesThePreviousClientWhenSwitchingToMocking(t *testing.T) {

--- a/metrics.go
+++ b/metrics.go
@@ -19,6 +19,12 @@ import (
 
 var DefaultCloseTimeout = time.Second * 10
 
+// DefaultRefreshInterval is how often the UDP statsd client is rebuilt when the
+// caller has not chosen a cadence. Five minutes is a compromise: long enough that
+// the rebuild is invisible next to a 2s reporting interval, short enough that a
+// process cannot spend hours reporting into a socket that goes nowhere.
+var DefaultRefreshInterval = time.Minute * 5
+
 func ReportFunc(fn, action string, tags ...Tags) {
 	reportFunc(fn, action, tags...)
 }

--- a/metrics.go
+++ b/metrics.go
@@ -23,7 +23,7 @@ var DefaultCloseTimeout = time.Second * 10
 // caller has not chosen a cadence. Five minutes is a compromise: long enough that
 // the rebuild is invisible next to a 2s reporting interval, short enough that a
 // process cannot spend hours reporting into a socket that goes nowhere.
-var DefaultRefreshInterval = time.Minute * 5
+const DefaultRefreshInterval = time.Minute * 5
 
 func ReportFunc(fn, action string, tags ...Tags) {
 	reportFunc(fn, action, tags...)

--- a/metrics.go
+++ b/metrics.go
@@ -172,7 +172,7 @@ func reportTiming(ctx context.Context, fn string, tags ...Tags) (context.Context
 
 	doneC := make(chan struct{})
 	go func(name string, start time.Time) {
-		timeout := time.NewTimer(config.StuckFunctionTimeout)
+		timeout := time.NewTimer(currentConfig().StuckFunctionTimeout)
 		defer timeout.Stop()
 
 		select {
@@ -219,7 +219,7 @@ func ReportClosureFuncTiming(name string, tags ...Tags) StopTimerFunc {
 
 	doneC := make(chan struct{})
 	go func(name string, start time.Time) {
-		timeout := time.NewTimer(config.StuckFunctionTimeout)
+		timeout := time.NewTimer(currentConfig().StuckFunctionTimeout)
 		defer timeout.Stop()
 
 		select {
@@ -397,7 +397,7 @@ func joinDDTags(tags ...Tags) []string {
 
 // JoinTags decides how to join tags base on agent
 func JoinTags(tags ...Tags) []string {
-	if config.Agent == DatadogAgent {
+	if currentConfig().Agent == DatadogAgent {
 		return joinDDTags(tags...)
 	}
 
@@ -405,7 +405,7 @@ func JoinTags(tags ...Tags) []string {
 }
 
 func getSingleTag(key, value string) string {
-	if config.Agent == DatadogAgent {
+	if currentConfig().Agent == DatadogAgent {
 		return fmt.Sprintf("%s:%s", key, value)
 	}
 


### PR DESCRIPTION
## The bug

The Telegraf and DataDog statters resolve their address and dial **once**, at construction, then hold that socket for the life of the process.

Nothing in the write path can notice when that socket stops being delivered — because there is nothing to notice. A connectionless send to a dead peer still succeeds locally, and no signal comes back. A process that outlives the agent it was pointed at keeps "reporting" into a hole: silently, with no errors, looking perfectly healthy the whole time.

## How it was found

On 2026-09-02 this was found across an entire cluster. Every one of the **46 statsd-emitting pods** on `ovh-prod-mainnet-eu` that had started before its node's otel-agent was replaced had stopped reporting:

- the agents' statsd receivers had accepted **zero** points in 18h
- the pods logged nothing and stayed `Ready`
- config, NetworkPolicy, Cilium service programming and DNS all checked out
- a probe packet sent by hand to the same Service address **arrived immediately**

That last point is what narrowed it to the senders' held sockets rather than to anything on the receiving side. The metrics only came back when the pods were restarted, by hand, one deployment at a time.

**Re-resolving DNS would not have caught this.** The Service ClusterIP never changed — only the pod behind it did. Rebuilding the socket is what recovers.

## The fix

Rebuild the UDP client every `DefaultRefreshInterval` (5m). A rebuild is a UDP dial with no handshake, and the replaced client is closed, which flushes whatever it had buffered.

```go
// InitService starts it automatically:
metrics.InitService(ctx, metrics.ServiceConfig{ /* ... */ })          // 5m default
metrics.InitService(ctx, metrics.ServiceConfig{RefreshInterval: -1})  // opt out

// Callers still on the plain Init path opt in with one line:
metrics.Init(addr, prefix, cfg)
metrics.StartRefresh(ctx, addr, prefix, 0)
```

## Notable details

- **`Init` was leaking clients.** It overwrote the package-level `client` without closing it — the old socket and its flush goroutine stayed around. Harmless when `Init` ran once per process; a real leak now that it can run repeatedly. `swapStatter` closes what it replaces.
- **A failed rebuild keeps the working client** rather than installing `nil`, which would silently drop every metric. Covered by a test.
- **OTEL is deliberately excluded** — it exports over gRPC/HTTP and redials on its own; rebuilding its exporter on a timer would discard batched points for no benefit.
- **On by default**, because the failure it prevents is silent, and a service that has stopped reporting looks exactly like a service with nothing to report.

`InitService` starts the loop itself. Services still on the plain `Init` path — which is most of the ones that broke, since they predate `InitService` — need the one-line `StartRefresh` opt-in.

## Tests

Nine new tests, all passing under `-race`:

```
TestSwapStatterClosesReplacedClient
TestSwapStatterFromEmpty
TestStatterNeedsRefresh
TestServiceConfigRefreshInterval
TestStartStatterRefreshRebuildsAndClosesTheOldClient
TestStartStatterRefreshStopsOnContextCancel
TestStartStatterRefreshKeepsClientWhenRebuildFails
TestStartRefreshIsANoOpWhenItCannotHelp
TestStartRefreshRebuildsForUDPAgents
```

Covering: the swap closes the replaced client, the loop stops on context cancel, a failed rebuild leaves the working client in place, and `StartRefresh` is a no-op when it cannot help (no `Init`, mocked, or a self-managing agent).

## Reviewer note

The `client.go` diff reads larger than it is — most of it is `Init`'s agent switch moving verbatim into `newStatter` so the refresh loop can rebuild *only* the statter. `Init` also wires up tracing, profiling and MixPanel, and those are process-global one-shot setups that must not be repeated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic UDP client refreshes every five minutes by default.
  - Added configurable refresh intervals, including the ability to disable refreshes.
  - Added support for manually starting client refreshes with direct initialization.
  - Refreshes stop when the provided context is canceled.
  - Reinitialization immediately retires earlier refresh loops and closes replaced clients.

- **Bug Fixes**
  - Failed initialization now preserves the active client and its configuration.

- **Documentation**
  - Documented UDP refresh behavior, configuration, and initialization requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->